### PR TITLE
fix: 비활성 계정 게이지가 access 토큰 만료 후 얼어붙는 문제 (+ transient 백오프)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,12 +73,19 @@ Sources/MobiusApp/        SwiftUI 메뉴바 앱 + AppState + Views/ + LoginFlow 
   refresh가 있으면 새로 쏘지 않고 그 결과에 합류하며, refresh 본체는 게이트 통과 후 스냅샷을
   **다시 읽는다**(직전 회전 반영 — FallbackAuthChecker.inFlight). refresh 지점을 늘리는
   변경(예: PR #2 팝오버 게이지 갱신)의 전제 조건.
-- **트리거**: (1) 팝오버 = **네트워크 0 로컬 검사만**(빈/시간만료 refresh 토큰 즉시 플래그),
+- **트리거**: (1) 팝오버의 **폴백 로컬 검증**(validateFallbacksLocally) = **네트워크 0 로컬
+  검사만**(빈/시간만료 refresh 토큰 즉시 플래그) — 팝오버 자체가 네트워크 0이란 뜻은 아니다((5) 예외),
   (2) **자동 폴백 전환 직전** = 실제 refresh(onTick(A)가 매 틱 재시도 → 죽은 폴백 스킵→다음 자동),
   (3) **수동 전환(계정 클릭)** = 대상 계정 refresh 1회(살았는지+신선한 토큰), (4) **만료 임박
   자동 갱신** = 폴백의 refreshTokenExpiresAt가 3일 이내면 1시간 스윕·계정당 6시간 간격으로 미리
-  refresh(안 쓰던 폴백이 몇 주 뒤 조용히 죽는 것 방지). refresh는 access·refresh 토큰과 두 만료를
-  모두 갱신. → 매 팝오버 호출 없음 = 블락 위험 최소화.
+  refresh(안 쓰던 폴백이 몇 주 뒤 조용히 죽는 것 방지), (5) **비활성 계정 usage 조회 직전** =
+  저장 access 토큰이 이미 만료됐으면 refresh 후 조회(refreshUsageIfStale). 안 그러면 만료 토큰으로
+  조회→429/401→조용히 스킵으로 **게이지가 마지막 스냅샷에 얼어붙어** 리셋이 안 되는 것처럼 보인다
+  (실측: 비활성 계정 access 만료 후 게이지 프리즈). access TTL≈1h라 갱신 후 만료 조건이 풀려
+  재-refresh는 자연히 멈춘다(스톰 없음). **★ transient(네트워크/5xx) 실패 시엔 usage 캐시가 안
+  갱신돼 계속 stale로 남아 팝오버마다 회전 시도가 반복되므로, 계정당 재시도 쿨다운
+  (`usageRefreshRetryCooldown` 10분)으로 백오프한다 — 성공 시 즉시 해제(만료조건 자연 소멸).**
+  refresh는 access·refresh 토큰과 두 만료를 모두 갱신. → 매 팝오버 호출 없음 = 블락 위험 최소화.
 
 ### macOS 26 (Tahoe) 환경
 - 메뉴바 아이콘은 Control Center가 호스팅 — CGWindowList의 layer/owner로 존재 확인이 어려움.

--- a/Sources/MobiusApp/AppState.swift
+++ b/Sources/MobiusApp/AppState.swift
@@ -65,6 +65,11 @@ final class AppState: ObservableObject {
     static let proactiveRefreshSweepInterval: TimeInterval = 3600
     static let proactiveRefreshRenewWindow: TimeInterval = 3 * 24 * 3600
     static let proactiveRefreshPerAccountGate: TimeInterval = 6 * 3600
+    // 만료 토큰 게이지용 refresh(reactive)의 계정당 재시도 쿨다운 — transient(네트워크/5xx)
+    // 실패 시 usage 캐시가 안 갱신돼 계속 stale로 남으므로, 이게 없으면 팝오버를 여닫을
+    // 때마다 회전 시도가 반복된다. 성공하면 즉시 해제(exp가 미래로 풀려 재진입도 자연히 멈춤).
+    private var lastUsageRefreshAttemptAt: [UUID: Date] = [:]
+    static let usageRefreshRetryCooldown: TimeInterval = 600
 
     init() {
         let env = MobiusEnvironment.live()
@@ -141,8 +146,48 @@ final class AppState: ObservableObject {
                 if isActive, let live = try? io.readLiveSnapshot() { blob = live.keychainBlob }
                 else { blob = (try? store.secret(for: profile.id))?.keychainBlob }
                 guard let blob else { continue }
+                // 비활성 계정의 저장 access 토큰이 만료됐으면 게이지를 못 읽어 얼어붙는다
+                // (429/401 → 조용히 continue). 폴백 refresh 기계로 미리 갱신한다 — 활성은
+                // check의 첫 guard가 절대 건드리지 않고, 회전 토큰은 원자 저장되며,
+                // refresh 토큰이 만료/폐기면 needsReauth로 마킹된다(계정당 access TTL≈1h라
+                // 갱신 후엔 만료 조건이 풀려 재-refresh가 자연히 멈춘다 = 스톰 없음).
+                var fetchBlob = blob
+                if !isActive, !profile.needsReauth,
+                   let exp = UsageFetcher.expiresAt(from: blob), exp <= now {
+                    // 계정당 쿨다운: 최근 시도가 있으면 이번 라운드는 아예 건너뛴다(만료 토큰이라
+                    // 어차피 게이지도 못 읽는다). transient 실패가 팝오버마다 회전 시도로 반복되지
+                    // 않게 하는 것 — 첫 시도는 게이팅 안 됨(distantPast)이라 프리즈 해소는 유지.
+                    guard now.timeIntervalSince(lastUsageRefreshAttemptAt[profile.id] ?? .distantPast)
+                            >= Self.usageRefreshRetryCooldown else { continue }
+                    lastUsageRefreshAttemptAt[profile.id] = now
+                    switch await fallbackChecker.check(profile.id,
+                                                       activeAccountID: store.file.activeAccountID,
+                                                       now: now, allowNetwork: true) {
+                    case .refreshedAlive:
+                        lastUsageRefreshAttemptAt[profile.id] = nil   // 성공 — 쿨다운 해제
+                        if let fresh = (try? store.secret(for: profile.id))?.keychainBlob {
+                            fetchBlob = fresh
+                        }
+                    case .dead, .storeFailed:
+                        // **네트워크로만 알 수 있는** 죽음(invalid_grant / 저장 실패) — 매 팝오버
+                        // 함께 도는 validateFallbacksLocally는 로컬 검사(allowNetwork:false)라
+                        // 못 잡는다. 여기서 알림을 전담한다(check가 이미 needsReauth 마킹).
+                        reauthChanged = true
+                        notify(title: loc("재로그인 필요"),
+                               body: loc("%@ 계정의 인증이 만료됐어요. 카드의 '다시 로그인'을 눌러주세요.", profile.nickname))
+                        continue
+                    case .locallyDead, .noRefreshToken:
+                        // **로컬로 판정 가능**한 죽음 — 매 팝오버 함께 도는 validateFallbacksLocally가
+                        // 알림을 전담하므로(같은 계정에 알림 2개 방지) 여기선 알리지 않는다.
+                        // check가 켠 needsReauth 반영(reload)만 하고 조용히 스킵.
+                        reauthChanged = true
+                        continue
+                    case .transient, .notFallback, .noSecret:
+                        continue   // 갱신 실패/불가 — 쿨다운 뒤 재시도
+                    }
+                }
                 do {
-                    guard let snap = try await UsageFetcher.fetch(keychainBlob: blob)
+                    guard let snap = try await UsageFetcher.fetch(keychainBlob: fetchBlob)
                     else { continue }
                     usage[profile.id] = snap
                     // 조회 성공 = 토큰 살아있음 → 잘못 남은 재로그인 마킹 자가 해제
@@ -168,7 +213,9 @@ final class AppState: ObservableObject {
                     // 활성도 잠자기 등으로 claude가 안 돌면 라이브 토큰이 만료된 채 남는다
                     // (이슈 #4: 오마킹 → 엔진이 멀쩡한 주계정을 밀어내던 연쇄의 수정).
                     // 판정 규칙은 UsageFetcher.shouldMarkReauthAfterAuthError 참조.
-                    if UsageFetcher.shouldMarkReauthAfterAuthError(blob: blob, isActive: isActive),
+                    // ★ 판정 대상은 fetchBlob: refresh 성공 시 fetchBlob은 신선한(유효) 토큰이라
+                    //   그래도 401이면 폐기로 마킹, refresh를 안 한 경로면 fetchBlob==blob.
+                    if UsageFetcher.shouldMarkReauthAfterAuthError(blob: fetchBlob, isActive: isActive),
                        !profile.needsReauth {
                         try? store.setNeedsReauth(profile.id, true)
                         reauthChanged = true


### PR DESCRIPTION
## 문제
지금 쓰고 있지 않은 계정(비활성 계정)의 사용량 게이지가 어느 순간부터 값이 바뀌지 않고
멈춰 있습니다. 한도가 리셋돼도 게이지는 옛 값 그대로라, 리셋이 안 된 것처럼 보입니다.

## 원인
게이지는 팝오버를 열 때 각 계정의 저장된 access 토큰으로 사용량을 조회합니다. 그런데
비활성 계정의 access 토큰은 약 1시간이면 만료됩니다. 만료된 토큰으로 조회하면 서버가
401/429로 거절하고, 앱은 이를 조용히 건너뛰어 게이지를 갱신하지 않습니다. 그래서 마지막에
성공한 값에 멈춰 버립니다. (이 동작은 upstream/main에도 그대로 있습니다.)

## 바꾼 것
조회 직전에 토큰 만료를 확인하고, 만료됐으면 먼저 refresh한 뒤 새 토큰으로 조회합니다.
- 대상은 "비활성 + 재로그인 대기(needsReauth) 아님 + 저장 토큰이 이미 만료됨"인 계정뿐입니다.
- 회전된 새 토큰은 원자적으로 저장하고, refresh 토큰이 폐기/만료됐으면 needsReauth로 표시합니다.
- (`refreshUsageIfStale`에서 `FallbackAuthChecker.check(allowNetwork: true)` 호출)

## 왜 안전한가
- **활성 계정은 절대 refresh하지 않습니다.** 활성 계정의 토큰은 claude가 직접 관리하므로,
  앱이 동시에 refresh하면 세션이 깨질 수 있어서입니다. (check 함수의 첫 guard가 활성 계정 제외)
- access 토큰 수명이 약 1시간이라, 한 번 갱신하면 "이미 만료됨" 조건이 풀려 계속 refresh하지
  않습니다(무한 반복 없음).
- **transient(네트워크·5xx) 실패 대비**: refresh가 일시적으로 실패하면 사용량 캐시가 갱신되지
  않아, 팝오버를 여닫을 때마다 refresh를 다시 시도할 수 있습니다. 그래서 계정당 10분 재시도
  쿨다운을 뒀습니다(첫 시도는 비게이팅, 성공하면 즉시 해제).

## 리뷰 반영 (v2)
메인테이너 리뷰 2건 + main 리베이스를 반영했습니다.
- **중복 알림 제거**: refresh 토큰이 죽은 폴백에서 이 경로와 `validateFallbacksLocally`(같은
  팝오버에서 함께 도는 로컬 검증)가 같은 계정에 "재로그인 필요" 알림을 2개 띄우던 문제를
  고쳤습니다. 로컬로 판정 가능한 `.locallyDead`/`.noRefreshToken`은 `validateFallbacksLocally`가
  알림을 전담하고, 이 경로는 **네트워크로만 알 수 있는 `.dead`/`.storeFailed`에서만** 알립니다
  (마킹·`reauthChanged`·`continue`는 네 케이스 모두 유지).
- **CLAUDE.md 트리거 (5) 추가**: OAuth refresh 트리거 목록에 "비활성 계정 usage 조회 직전 +
  계정당 쿨다운 10분"을 (5)로 명시했습니다. 트리거 (1) "팝오버 = 네트워크 0"이 (5)와 어긋나
  보이지 않게 (1)은 *폴백 로컬 검증*에 한정됨을 함께 명확화했습니다.
- **main(v0.2.4) 리베이스**: 같은 계정 동시 refresh 레이스는 upstream 합류(coalesce) 게이트
  (43cd116)가 구조적으로 처리하며, 파일이 겹치지 않아 충돌 없이 리베이스했습니다. 401 오마킹
  판정은 이슈 #4의 `shouldMarkReauthAfterAuthError`와 통합하되 refresh 반영된 `fetchBlob` 기준으로
  재계산합니다.

## 검토 포인트 — OAuth refresh 지점 하나 추가
이 변경으로 refresh가 일어나는 지점이 하나 늘어납니다: "비활성 계정 사용량 조회 직전".
계정 보호상 민감한 부분이라 명시합니다. 새 지점도 기존 refresh와 같은 규칙(활성 계정 제외,
새 토큰 원자 저장, 폐기 시 needsReauth 표시)을 따릅니다.

## 테스트
swift build 통과 · swift test 108개 통과(리베이스로 이슈 #4·합류 게이트 테스트 포함).
추가로 적대적 코드리뷰를 돌려 findings를 실코드로 재검증했습니다(라이브 자격증명 회전 경계는
합류 게이트+preflight+전환 시 스냅샷 재읽기로 완화 확인).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
