### PR TITLE
perf: Codex 세션 스캔이 매 틱 세션 폴더 전체(5만 파일)를 훑던 문제 — 유휴 CPU 19%→0.1%

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,17 +130,21 @@ Sources/MobiusApp/        SwiftUI 메뉴바 앱 + AppState + Views/ + LoginFlow 
 - ★ **`codex resume`는 며칠 지난 원본 rollout 파일에 이어 쓴다**(실측: 7/8 파일이 7/12 갱신).
   세션 로그가 수만 개(실측 49K, 19GB)라 Claude식 전체 프라이밍 불가 →
   SessionLogWatcher **tailOnly 정책**: 오래된 미추적 파일 무시, 처음 본 파일은 끝까지 스킵 후
-  append만 파싱, 오래되면 추적 해제.
+  append만 파싱. **오프셋은 유지한다**(유휴 후 첫 append가 재프라이밍에 삼켜지지 않도록 —
+  `testTrackedFileKeepsOffsetAcrossStaleness`가 보증; 아래 direct-stat 안전망도 이 유지에
+  의존). 삭제된 파일만 추적 해제.
 - ★ **날짜 파티션 프루닝 — 매 틱 전수 walk 금지**: 루트가 `YYYY/MM/DD`인데 전체(49K/19GB)를
   `FileManager.enumerator`로 훑으면 `getattrlistbulk`가 매 3초 틱마다 CPU를 태운다(실측: 유휴
   앱 CPU **19~21%**, `sample` 스택 최다 getattrlistbulk). 로그 스캔은 15초 게이트 밖이라 실제로
   매 3초 돈다 — 디렉토리가 커지며 "0.1s면 허용"이 낡았다(0.25s+, cold면 더). →
-  `SessionLogWatcher.recentDirs` 주입으로 **최근 N일(Codex=7) 날짜 폴더만 열거**(신규 발견) +
-  **추적 중인 파일은 폴더 나이 무관하게 직접 확인**(옛 폴더 resume append 유지). 실측: 열거
-  49,296→7,494개(6.6배↓), 최근 수정분 누락 0, 유휴 CPU 19%→**0.1%**, getattrlistbulk
-  3702→108. 잔여(문서화된 트레이드오프): N일보다 오래 유휴였던 미추적 파일의 resume는 발견
-  못 함 — 계정 한도는 계정 전역이라 활성/최근 세션 이벤트로 교차 반영된다. Claude 워처는
-  프로젝트별 구조라 프루닝 미적용(전체 열거 유지, 부하 작음).
+  `SessionLogWatcher.recentDirs` 주입으로 **최근 N일(Codex=7, +내일까지) 날짜 폴더만 열거**(신규
+  발견) + **추적 중인 파일은 폴더 나이 무관하게 직접 확인**(옛 폴더 resume append 유지).
+  **첫 스캔(프라이밍)은 프루닝 없이 전수 열거**해 창 밖 옛 폴더의 최근 파일까지 시딩한다 —
+  offsets가 메모리 전용이라 재시작/오프라인 후 옛 세션 resume이 끊기지 않게(리뷰 반영, 1회
+  비용). 실측: 열거 49,296→7,494개(6.6배↓), 최근 수정분 누락 0, 유휴 CPU 19%→**0.1%**,
+  getattrlistbulk 3702→108. 잔여(축소된 트레이드오프): **프라이밍 이후 실행 중 처음 resume되는**
+  N일+ 옛 폴더 세션만 못 봄(재시작 시 재시딩) — 계정 한도는 계정 전역이라 활성/최근 세션
+  이벤트로 교차 반영된다. Claude 워처는 프로젝트별 구조라 프루닝 미적용(전체 열거 유지, 부하 작음).
 - `codex login status`는 읽기 전용(해시·mtime 불변 실측), 로그인 시 exit 0 — E2E 검증 프리미티브.
 - `codex login`(브라우저 OAuth)·`codex logout` 존재. `CODEX_HOME`으로 루트 오버라이드 가능.
 - ★ **구 계정 세션의 리프레시가 로그인을 되돌린다(클로버)** — B 계정으로 로그인/전환해도,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,9 +128,19 @@ Sources/MobiusApp/        SwiftUI 메뉴바 앱 + AppState + Views/ + LoginFlow 
 - 활성 codex 계정이 이미 한도 기록 중이면 추가 소진 상태는 처리하지 않는다 —
   매 턴 상태가 오므로 이 가드가 없으면 15초마다 알림·엔진 호출이 반복된다(알림 폭풍).
 - ★ **`codex resume`는 며칠 지난 원본 rollout 파일에 이어 쓴다**(실측: 7/8 파일이 7/12 갱신).
-  세션 로그가 수만 개(실측 46K, 18GB)라 Claude식 전체 프라이밍 불가 →
+  세션 로그가 수만 개(실측 49K, 19GB)라 Claude식 전체 프라이밍 불가 →
   SessionLogWatcher **tailOnly 정책**: 오래된 미추적 파일 무시, 처음 본 파일은 끝까지 스킵 후
-  append만 파싱, 오래되면 추적 해제. 전체 열거+stat은 0.1s(실측)라 15초 틱에 허용.
+  append만 파싱, 오래되면 추적 해제.
+- ★ **날짜 파티션 프루닝 — 매 틱 전수 walk 금지**: 루트가 `YYYY/MM/DD`인데 전체(49K/19GB)를
+  `FileManager.enumerator`로 훑으면 `getattrlistbulk`가 매 3초 틱마다 CPU를 태운다(실측: 유휴
+  앱 CPU **19~21%**, `sample` 스택 최다 getattrlistbulk). 로그 스캔은 15초 게이트 밖이라 실제로
+  매 3초 돈다 — 디렉토리가 커지며 "0.1s면 허용"이 낡았다(0.25s+, cold면 더). →
+  `SessionLogWatcher.recentDirs` 주입으로 **최근 N일(Codex=7) 날짜 폴더만 열거**(신규 발견) +
+  **추적 중인 파일은 폴더 나이 무관하게 직접 확인**(옛 폴더 resume append 유지). 실측: 열거
+  49,296→7,494개(6.6배↓), 최근 수정분 누락 0, 유휴 CPU 19%→**0.1%**, getattrlistbulk
+  3702→108. 잔여(문서화된 트레이드오프): N일보다 오래 유휴였던 미추적 파일의 resume는 발견
+  못 함 — 계정 한도는 계정 전역이라 활성/최근 세션 이벤트로 교차 반영된다. Claude 워처는
+  프로젝트별 구조라 프루닝 미적용(전체 열거 유지, 부하 작음).
 - `codex login status`는 읽기 전용(해시·mtime 불변 실측), 로그인 시 exit 0 — E2E 검증 프리미티브.
 - `codex login`(브라우저 OAuth)·`codex logout` 존재. `CODEX_HOME`으로 루트 오버라이드 가능.
 - ★ **구 계정 세션의 리프레시가 로그인을 되돌린다(클로버)** — B 계정으로 로그인/전환해도,

--- a/Sources/MobiusCore/SessionLogWatcher.swift
+++ b/Sources/MobiusCore/SessionLogWatcher.swift
@@ -37,7 +37,8 @@ public final class SessionLogWatcher<Event: Sendable>: @unchecked Sendable {
     /// 며칠 지난 옛 폴더의 resume append도 놓치지 않는다.
     let recentDirs: (@Sendable (_ now: Date) -> [URL]?)?
     private var offsets: [String: UInt64] = [:]   // 파일 경로 → 읽은 위치
-    private var primed = false                    // 첫 스캔 여부 (parseFromStart에서만 의미)
+    private var primed = false                    // 첫 스캔 여부 — parseFromStart의 프라이밍 판정
+                                                  // + recentDirs 프루닝 게이트(첫 스캔은 전수 시딩)
     private let lock = NSLock()
     /// 이 시간 안에 수정된 파일만 본다
     public var recentWindow: TimeInterval = 600

--- a/Sources/MobiusCore/SessionLogWatcher.swift
+++ b/Sources/MobiusCore/SessionLogWatcher.swift
@@ -65,9 +65,14 @@ public final class SessionLogWatcher<Event: Sendable>: @unchecked Sendable {
         // recentDirs 주입 시(Codex, 날짜 파티션): 최근 창의 폴더만 열거해 수만 파일 전수 walk를
         //   피하고, 추적 중인 파일은 폴더 나이와 무관하게 직접 포함한다(옛 폴더 resume의 append를
         //   놓치지 않도록). 사라진 파일의 오프셋은 함께 정리해 추적 집합이 무한정 커지지 않게 한다.
+        // ★ 단 첫 스캔(프라이밍)은 프루닝하지 않고 root 전체를 열거한다 — offsets가 메모리
+        //   전용이라 앱 재시작(또는 Mobius가 꺼진 채 codex 사용) 후엔 추적이 리셋되는데, 그때
+        //   창 밖 옛 폴더에서 이미 최근 수정된 세션(resume 중)을 시딩해 둬야 이후 direct-stat이
+        //   그 append를 이어 잡는다. 프라이밍은 파싱 없이 오프셋만 기록하므로 부작용 없이 1회
+        //   비용(전수 열거)뿐이고, 스캔은 유틸리티 태스크라 UI를 막지 않는다.
         // 미주입 시(Claude, 프로젝트별 구조): 기존대로 root 전체를 재귀 열거.
         let candidates: [URL]
-        if let recentDirs, let dirs = recentDirs(now) {
+        if let recentDirs, primed, let dirs = recentDirs(now) {
             var seen = Set<String>()
             var urls: [URL] = []
             for dir in dirs {
@@ -190,17 +195,24 @@ extension SessionLogWatcher where Event == CodexRateLimitStatus {
     /// 이보다 오래 전에 마지막으로 본 파일도 한 번 추적되면 recentDirs 밖 직접 확인으로 이어진다.
     static let codexLookbackDays = 7
 
+    /// 날짜 파티션 폴더 경로(root/YYYY/MM/DD) — 로컬 날짜 기준. 테스트도 이 함수를 직접 호출해
+    /// 경로 계산이 프로덕션과 어긋날 여지를 없앤다.
+    static func dateDir(root: URL, for date: Date) -> URL {
+        var cal = Calendar(identifier: .gregorian); cal.timeZone = .current
+        let c = cal.dateComponents([.year, .month, .day], from: date)
+        return root
+            .appendingPathComponent(String(format: "%04d", c.year ?? 0))
+            .appendingPathComponent(String(format: "%02d", c.month ?? 0))
+            .appendingPathComponent(String(format: "%02d", c.day ?? 0))
+    }
+
+    /// 최근 창의 날짜 폴더들. **내일(+1)까지 포함** — 폴더 명명이 로컬 날짜라 타임존 변경·시계
+    /// 스큐로 세션이 '내일' 폴더에 떨어져도 잡히게 하는 공짜 보험(없는 폴더 열거는 no-op).
+    /// 어제~`days`일 전은 옛 세션 resume 지평(실측 7/8→7/12=4일)을 커버한다.
     static func recentDateDirs(root: URL, now: Date, days: Int) -> [URL] {
-        var cal = Calendar(identifier: .gregorian)
-        cal.timeZone = .current
-        return (0...days).compactMap { back -> URL? in
-            guard let day = cal.date(byAdding: .day, value: -back, to: now) else { return nil }
-            let c = cal.dateComponents([.year, .month, .day], from: day)
-            guard let y = c.year, let m = c.month, let d = c.day else { return nil }
-            return root
-                .appendingPathComponent(String(format: "%04d", y))
-                .appendingPathComponent(String(format: "%02d", m))
-                .appendingPathComponent(String(format: "%02d", d))
+        var cal = Calendar(identifier: .gregorian); cal.timeZone = .current
+        return (-1...days).compactMap { back in
+            cal.date(byAdding: .day, value: -back, to: now).map { dateDir(root: root, for: $0) }
         }
     }
 

--- a/Sources/MobiusCore/SessionLogWatcher.swift
+++ b/Sources/MobiusCore/SessionLogWatcher.swift
@@ -30,6 +30,12 @@ public final class SessionLogWatcher<Event: Sendable>: @unchecked Sendable {
     let root: URL
     let policy: UnseenFilePolicy
     let parse: @Sendable (_ line: String, _ now: Date) -> Event?
+    /// 이번 스캔에서 열거할 하위 디렉토리를 좁히는 선택자(주입). nil이면 root 전체를 재귀 열거.
+    /// 날짜 파티션 루트(Codex: YYYY/MM/DD, 실측 5만 파일/19GB)에서 최근 창의 폴더만 열거해
+    /// 매 틱 전수 walk(getattrlistbulk)로 CPU를 태우는 것을 막는다. 좁힌 열거는 "새 파일 발견"
+    /// 용도이고, 이미 추적 중인 파일은 폴더 나이와 무관하게 직접 확인하므로(아래 scanBatches)
+    /// 며칠 지난 옛 폴더의 resume append도 놓치지 않는다.
+    let recentDirs: (@Sendable (_ now: Date) -> [URL]?)?
     private var offsets: [String: UInt64] = [:]   // 파일 경로 → 읽은 위치
     private var primed = false                    // 첫 스캔 여부 (parseFromStart에서만 의미)
     private let lock = NSLock()
@@ -37,9 +43,11 @@ public final class SessionLogWatcher<Event: Sendable>: @unchecked Sendable {
     public var recentWindow: TimeInterval = 600
 
     public init(root: URL, policy: UnseenFilePolicy = .parseFromStart,
+                recentDirs: (@Sendable (_ now: Date) -> [URL]?)? = nil,
                 parse: @escaping @Sendable (_ line: String, _ now: Date) -> Event?) {
         self.root = root
         self.policy = policy
+        self.recentDirs = recentDirs
         self.parse = parse
     }
 
@@ -52,10 +60,41 @@ public final class SessionLogWatcher<Event: Sendable>: @unchecked Sendable {
         lock.lock(); defer { lock.unlock() }
         var batches: [Batch] = []
         let fm = FileManager.default
-        guard let en = fm.enumerator(at: root,
-                                     includingPropertiesForKeys: [.contentModificationDateKey])
-        else { return [] }
-        for case let url as URL in en where url.pathExtension == "jsonl" {
+
+        // 후보 파일 수집.
+        // recentDirs 주입 시(Codex, 날짜 파티션): 최근 창의 폴더만 열거해 수만 파일 전수 walk를
+        //   피하고, 추적 중인 파일은 폴더 나이와 무관하게 직접 포함한다(옛 폴더 resume의 append를
+        //   놓치지 않도록). 사라진 파일의 오프셋은 함께 정리해 추적 집합이 무한정 커지지 않게 한다.
+        // 미주입 시(Claude, 프로젝트별 구조): 기존대로 root 전체를 재귀 열거.
+        let candidates: [URL]
+        if let recentDirs, let dirs = recentDirs(now) {
+            var seen = Set<String>()
+            var urls: [URL] = []
+            for dir in dirs {
+                guard let en = fm.enumerator(at: dir,
+                                             includingPropertiesForKeys: [.contentModificationDateKey])
+                else { continue }
+                for case let url as URL in en where url.pathExtension == "jsonl" {
+                    if seen.insert(url.path).inserted { urls.append(url) }
+                }
+            }
+            // 추적 중이지만 최근 폴더 밖에 있는 파일(며칠 전 세션 resume)도 직접 확인 대상에 넣는다.
+            for path in offsets.keys where seen.insert(path).inserted {
+                if fm.fileExists(atPath: path) {
+                    urls.append(URL(fileURLWithPath: path))
+                } else {
+                    offsets[path] = nil // 삭제된 파일 — 추적 해제
+                }
+            }
+            candidates = urls
+        } else {
+            guard let en = fm.enumerator(at: root,
+                                         includingPropertiesForKeys: [.contentModificationDateKey])
+            else { return [] }
+            candidates = en.compactMap { $0 as? URL }.filter { $0.pathExtension == "jsonl" }
+        }
+
+        for url in candidates {
             let mtime = (try? url.resourceValues(forKeys: [.contentModificationDateKey])
                 .contentModificationDate) ?? .distantPast
             let recent = mtime > now.addingTimeInterval(-recentWindow)
@@ -146,11 +185,37 @@ extension SessionLogWatcher where Event == RateLimitHit {
 }
 
 extension SessionLogWatcher where Event == CodexRateLimitStatus {
+    /// 최근 `days`일(당일 포함)의 날짜 파티션 폴더 경로 목록 — 옛 세션 resume 지평까지 커버.
+    /// 실측: resume는 며칠 지난 파일에 이어 쓴다(7/8→7/12=4일). 넉넉히 7일을 열거 대상으로 잡되,
+    /// 이보다 오래 전에 마지막으로 본 파일도 한 번 추적되면 recentDirs 밖 직접 확인으로 이어진다.
+    static let codexLookbackDays = 7
+
+    static func recentDateDirs(root: URL, now: Date, days: Int) -> [URL] {
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = .current
+        return (0...days).compactMap { back -> URL? in
+            guard let day = cal.date(byAdding: .day, value: -back, to: now) else { return nil }
+            let c = cal.dateComponents([.year, .month, .day], from: day)
+            guard let y = c.year, let m = c.month, let d = c.day else { return nil }
+            return root
+                .appendingPathComponent(String(format: "%04d", y))
+                .appendingPathComponent(String(format: "%02d", m))
+                .appendingPathComponent(String(format: "%02d", d))
+        }
+    }
+
     /// Codex 세션 로그 감시 (~/.codex/sessions + CodexRateLimitParser).
     /// tailOnly — 세션 로그가 수만 개이고 resume가 옛 파일에 이어 쓰므로(실측)
-    /// 히스토리 재생 없이 새 append만 본다.
+    /// 히스토리 재생 없이 새 append만 본다. 루트가 YYYY/MM/DD 날짜 파티션이라 최근 창의 폴더만
+    /// 열거(recentDirs)해 매 틱 전수 walk를 피한다 — 추적된 파일의 append는 폴더 나이와 무관하게 잡힌다.
     public static func codex(env: MobiusEnvironment) -> SessionLogWatcher<CodexRateLimitStatus> {
-        SessionLogWatcher(root: env.codexSessionsDir, policy: .tailOnly) { line, _ in
+        let root = env.codexSessionsDir
+        let days = codexLookbackDays
+        return SessionLogWatcher(
+            root: root,
+            policy: .tailOnly,
+            recentDirs: { now in recentDateDirs(root: root, now: now, days: days) }
+        ) { line, _ in
             CodexRateLimitParser.parse(line: line)
         }
     }

--- a/Tests/MobiusCoreTests/CodexSessionWatcherTests.swift
+++ b/Tests/MobiusCoreTests/CodexSessionWatcherTests.swift
@@ -22,15 +22,12 @@ final class CodexSessionWatcherTests: XCTestCase {
     }
     override func tearDownWithError() throws { try? FileManager.default.removeItem(at: tmp) }
 
-    /// 기준 시각에서 daysAgo일 전의 날짜 파티션 폴더 (프로덕션 recentDateDirs와 동일 계산).
+    /// 기준 시각에서 daysAgo일 전의 날짜 파티션 폴더. 경로 계산은 프로덕션 헬퍼를 직접 호출해
+    /// (@testable) 테스트와 프로덕션이 어긋날 여지를 없앤다.
     func folder(daysAgo: Int) -> URL {
         var cal = Calendar(identifier: .gregorian); cal.timeZone = .current
         let day = cal.date(byAdding: .day, value: -daysAgo, to: now)!
-        let c = cal.dateComponents([.year, .month, .day], from: day)
-        return env.codexSessionsDir
-            .appendingPathComponent(String(format: "%04d", c.year!))
-            .appendingPathComponent(String(format: "%02d", c.month!))
-            .appendingPathComponent(String(format: "%02d", c.day!))
+        return SessionLogWatcher<CodexRateLimitStatus>.dateDir(root: env.codexSessionsDir, for: day)
     }
 
     func statusLine(pct: Double) -> String {
@@ -153,17 +150,32 @@ final class CodexSessionWatcherTests: XCTestCase {
         XCTAssertEqual(watcher.scan(now: now).map(\.primary?.usedPercent), [99.0])
     }
 
-    /// lookback 창 밖 폴더의 파일이 '한 번도 추적된 적 없이' resume되면 발견되지 않는다.
-    /// 성능(전수 walk 회피)을 위한 의도적 트레이드오프 — 계정 한도는 계정 전역이라
-    /// 활성/최근 세션 이벤트로 교차 반영되며, 이 잔여는 문서화된 선택이다.
-    func testUntrackedFileInAgedOutFolderIsNotDiscovered() throws {
-        let agedDir = folder(daysAgo: 400)
-        let f = agedDir.appendingPathComponent("rollout-cold.jsonl")
-        try append(statusLine(pct: 100.0), to: f)
-        try setMtime(f, now) // 최근 mtime이지만 폴더가 창 밖 + 미추적
+    /// 재시작 시딩(리뷰 반영): 창 밖(수백 일 전) 폴더의 세션이 최근 수정 상태로 이미 있으면,
+    /// 첫 스캔(프라이밍)의 전수 열거가 폴더 나이와 무관하게 시딩한다 → 이후 append를 tail.
+    /// 앱 재시작/오프라인 중 codex 사용 후 옛 세션을 resume해도 신호가 끊기지 않는다.
+    func testPrimingFullWalkSeedsRecentFileInAgedFolder() throws {
+        let f = folder(daysAgo: 400).appendingPathComponent("rollout-warm.jsonl")
+        try append(statusLine(pct: 90.0), to: f)
+        try setMtime(f, now) // 재시작 직전 resume되어 최근 상태
 
         let watcher = SessionLogWatcher.codex(env: env)
-        // 프라이밍 스캔조차 이 파일을 열거하지 않는다 → 이후에도 발견 안 됨.
+        XCTAssertTrue(watcher.scan(now: now).isEmpty) // 프라이밍: 전수 열거로 시딩(파싱 없음)
+        XCTAssertTrue(watcher.trackedFiles.contains { ($0 as NSString).lastPathComponent == "rollout-warm.jsonl" })
+
+        try append(statusLine(pct: 99.0), to: f)
+        XCTAssertEqual(watcher.scan(now: now).map(\.primary?.usedPercent), [99.0]) // direct-stat tail
+    }
+
+    /// 잔여 트레이드오프(축소됨): 프라이밍 이후 처음 resume되는 창 밖 세션은 프루닝이 못 본다.
+    /// 재시작하면 프라이밍 전수 열거가 다시 시딩하므로, 남는 갭은 "실행 중 첫 resume" 뿐이다.
+    /// 계정 한도는 계정 전역이라 활성/최근 세션 이벤트로 교차 반영된다.
+    func testAgedFolderFileResumedAfterPrimingIsNotDiscovered() throws {
+        let watcher = SessionLogWatcher.codex(env: env)
+        XCTAssertTrue(watcher.scan(now: now).isEmpty) // 프라이밍 (창 밖 파일 아직 없음)
+
+        let f = folder(daysAgo: 400).appendingPathComponent("rollout-cold.jsonl")
+        try append(statusLine(pct: 100.0), to: f)
+        try setMtime(f, now) // 프라이밍 후 처음 나타남 + 최근 mtime, 그러나 창 밖 폴더 + 미추적
         XCTAssertTrue(watcher.scan(now: now).isEmpty)
         try append(statusLine(pct: 100.0), to: f)
         XCTAssertTrue(watcher.scan(now: now).isEmpty)

--- a/Tests/MobiusCoreTests/CodexSessionWatcherTests.swift
+++ b/Tests/MobiusCoreTests/CodexSessionWatcherTests.swift
@@ -2,24 +2,44 @@ import XCTest
 @testable import MobiusCore
 
 /// tailOnly 정책(Codex 세션 감시)의 스펙: 히스토리 재생 금지, 오래된 파일 무시,
-/// resume로 되살아난 옛 파일의 append만 파싱.
+/// resume로 되살아난 옛 파일의 append만 파싱. 루트가 날짜 파티션(YYYY/MM/DD)이라
+/// 최근 창의 폴더만 열거하되(전수 walk 회피), 추적된 파일은 폴더 나이와 무관하게 tail한다.
 final class CodexSessionWatcherTests: XCTestCase {
     var tmp: URL!; var env: MobiusEnvironment!; var dayDir: URL!
+    /// 고정 기준 시각 — 폴더가 lookback 창 안/밖인지 판정이 "테스트를 언제 돌리는지"에
+    /// 흔들리지 않도록 실제 Date()가 아니라 이 값을 모든 scan에 넘긴다.
+    let now: Date = {
+        var cal = Calendar(identifier: .gregorian); cal.timeZone = .current
+        return cal.date(from: DateComponents(year: 2026, month: 7, day: 12, hour: 12))!
+    }()
 
     override func setUpWithError() throws {
         tmp = URL(fileURLWithPath: NSTemporaryDirectory())
             .appendingPathComponent("mobius-cxwatch-\(UUID().uuidString)")
         env = MobiusEnvironment(home: tmp, localUser: "tester")
-        dayDir = env.codexSessionsDir.appendingPathComponent("2026/07/12")
+        dayDir = folder(daysAgo: 0) // 기준일(당일) 폴더 — lookback 창 안
         try FileManager.default.createDirectory(at: dayDir, withIntermediateDirectories: true)
     }
     override func tearDownWithError() throws { try? FileManager.default.removeItem(at: tmp) }
+
+    /// 기준 시각에서 daysAgo일 전의 날짜 파티션 폴더 (프로덕션 recentDateDirs와 동일 계산).
+    func folder(daysAgo: Int) -> URL {
+        var cal = Calendar(identifier: .gregorian); cal.timeZone = .current
+        let day = cal.date(byAdding: .day, value: -daysAgo, to: now)!
+        let c = cal.dateComponents([.year, .month, .day], from: day)
+        return env.codexSessionsDir
+            .appendingPathComponent(String(format: "%04d", c.year!))
+            .appendingPathComponent(String(format: "%02d", c.month!))
+            .appendingPathComponent(String(format: "%02d", c.day!))
+    }
 
     func statusLine(pct: Double) -> String {
         #"{"timestamp":"2026-07-12T09:07:14.309Z","type":"event_msg","payload":{"type":"token_count","rate_limits":{"limit_id":"codex","primary":{"used_percent":\#(pct),"window_minutes":300,"resets_at":1783861033},"rate_limit_reached_type":null}}}"#
     }
 
     func append(_ line: String, to url: URL) throws {
+        try FileManager.default.createDirectory(at: url.deletingLastPathComponent(),
+                                                withIntermediateDirectories: true)
         if !FileManager.default.fileExists(atPath: url.path) {
             try Data().write(to: url)
         }
@@ -34,7 +54,6 @@ final class CodexSessionWatcherTests: XCTestCase {
     }
 
     func testExistingHistoryIsNotReplayed() throws {
-        let now = Date()
         let log = dayDir.appendingPathComponent("rollout-a.jsonl")
         try append(statusLine(pct: 100.0), to: log) // 과거 소진 이벤트 (재생되면 오탐)
 
@@ -47,7 +66,6 @@ final class CodexSessionWatcherTests: XCTestCase {
     }
 
     func testStaleUntrackedFileIsNeverOpened() throws {
-        let now = Date()
         let old = dayDir.appendingPathComponent("rollout-old.jsonl")
         try append(statusLine(pct: 100.0), to: old)
         try setMtime(old, now.addingTimeInterval(-3600)) // recentWindow(600s) 밖
@@ -59,7 +77,6 @@ final class CodexSessionWatcherTests: XCTestCase {
     }
 
     func testResumedOldFileTailsFromFirstSight() throws {
-        let now = Date()
         let old = dayDir.appendingPathComponent("rollout-resumed.jsonl")
         try append(statusLine(pct: 90.0), to: old)   // 옛 히스토리
         try setMtime(old, now.addingTimeInterval(-3600))
@@ -77,7 +94,6 @@ final class CodexSessionWatcherTests: XCTestCase {
     }
 
     func testTrackedFileKeepsOffsetAcrossStaleness() throws {
-        let now = Date()
         let log = dayDir.appendingPathComponent("rollout-b.jsonl")
         try append(statusLine(pct: 10.0), to: log)
         let watcher = SessionLogWatcher.codex(env: env)
@@ -95,7 +111,6 @@ final class CodexSessionWatcherTests: XCTestCase {
     }
 
     func testScanBatchesTagsFilePaths() throws {
-        let now = Date()
         let a = dayDir.appendingPathComponent("rollout-a.jsonl")
         let b = dayDir.appendingPathComponent("rollout-b.jsonl")
         try append(statusLine(pct: 1.0), to: a)
@@ -112,5 +127,55 @@ final class CodexSessionWatcherTests: XCTestCase {
         let batches = watcher.scanBatches(now: now)
         XCTAssertEqual(Set(batches.map(\.file)), watcher.trackedFiles) // 표기 일관성
         XCTAssertEqual(batches.flatMap(\.events).count, 2)
+    }
+
+    // MARK: 날짜 파티션 프루닝 (전수 walk 회피) — 성능 수정의 정확성 계약
+
+    /// lookback 창 밖(수백 일 전) 폴더의 파일도, 창 안에서 한 번 추적된 뒤라면
+    /// 폴더가 나이를 먹어 열거 대상에서 빠져도 직접 확인(direct-stat)으로 tail이 이어진다.
+    func testTrackedFileInAgedOutFolderStillTailsViaDirectStat() throws {
+        // 이 세션은 lookback(7일) 훨씬 밖의 옛 날짜 폴더에 산다.
+        let agedDir = folder(daysAgo: 400)
+        let f = agedDir.appendingPathComponent("rollout-aged.jsonl")
+        // 1) 그 폴더가 '최근'이던 시점(그 날짜 정오)에 스캔해 추적을 시작한다.
+        var cal = Calendar(identifier: .gregorian); cal.timeZone = .current
+        let agedDate = cal.date(byAdding: .day, value: -400, to: now)!
+        let pastNow = cal.date(bySettingHour: 12, minute: 0, second: 0, of: agedDate)!
+        try append(statusLine(pct: 30.0), to: f)
+        let watcher = SessionLogWatcher.codex(env: env)
+        XCTAssertTrue(watcher.scan(now: pastNow).isEmpty) // 프라이밍 (그 시점엔 창 안)
+        XCTAssertTrue(watcher.trackedFiles.contains { ($0 as NSString).lastPathComponent == "rollout-aged.jsonl" })
+
+        // 2) 기준 시각(now)으로 넘어오면 이 폴더는 lookback 창 밖 → 열거되지 않는다.
+        //    하지만 resume로 append가 생기면(최근 mtime) direct-stat이 잡아야 한다.
+        try append(statusLine(pct: 99.0), to: f)
+        try setMtime(f, now) // 최근 수정
+        XCTAssertEqual(watcher.scan(now: now).map(\.primary?.usedPercent), [99.0])
+    }
+
+    /// lookback 창 밖 폴더의 파일이 '한 번도 추적된 적 없이' resume되면 발견되지 않는다.
+    /// 성능(전수 walk 회피)을 위한 의도적 트레이드오프 — 계정 한도는 계정 전역이라
+    /// 활성/최근 세션 이벤트로 교차 반영되며, 이 잔여는 문서화된 선택이다.
+    func testUntrackedFileInAgedOutFolderIsNotDiscovered() throws {
+        let agedDir = folder(daysAgo: 400)
+        let f = agedDir.appendingPathComponent("rollout-cold.jsonl")
+        try append(statusLine(pct: 100.0), to: f)
+        try setMtime(f, now) // 최근 mtime이지만 폴더가 창 밖 + 미추적
+
+        let watcher = SessionLogWatcher.codex(env: env)
+        // 프라이밍 스캔조차 이 파일을 열거하지 않는다 → 이후에도 발견 안 됨.
+        XCTAssertTrue(watcher.scan(now: now).isEmpty)
+        try append(statusLine(pct: 100.0), to: f)
+        XCTAssertTrue(watcher.scan(now: now).isEmpty)
+    }
+
+    /// 당일 폴더의 새 세션 파일은 정상 발견된다 (프루닝이 최근 활동을 가리지 않는다).
+    func testTodayFolderNewFileIsDiscovered() throws {
+        let watcher = SessionLogWatcher.codex(env: env)
+        let f = folder(daysAgo: 0).appendingPathComponent("rollout-new.jsonl")
+        try append(statusLine(pct: 5.0), to: f)
+        XCTAssertTrue(watcher.scan(now: now).isEmpty)   // 프라이밍
+        try append(statusLine(pct: 55.0), to: f)
+        XCTAssertEqual(watcher.scan(now: now).map(\.primary?.usedPercent), [55.0])
     }
 }


### PR DESCRIPTION
## 한 줄 요약

Codex 게이지·메뉴바 드롭다운이 전반적으로 느려지고 앱이 유휴 상태에서도 CPU를 계속 먹던 문제를 고칩니다. **유휴 CPU 19~21% → 0.1%.**

## 무엇이 문제였나

앱은 3초마다 한 번씩 세션 로그 폴더를 훑어 "방금 바뀐 세션"을 찾습니다. 여기에 rate-limit(한도) 상태가 실려오기 때문입니다.

그런데 이 스캔이 매번 **폴더 트리 전체를 재귀 열거**하고 있었습니다. Codex 세션 폴더는 오래 쓸수록 쌓여 제 환경에서 **49,296개(19GB)** 인데, 방금 바뀐 몇 개(최근 10분 내 수십 개)를 찾으려고 매 틱마다 5만 개 전체를 열거한 것입니다. 폴더가 이미 날짜별(`YYYY/MM/DD`)로 나뉘어 있는데도요.

`sample`로 CPU 스택을 뜨니 시간을 가장 많이 먹는 함수가 디렉토리 열거(`getattrlistbulk`)였고, 호출처가 이 세션 스캔이었습니다.

## 왜 Claude에선 경미했고 Codex에선 컸나

같은 `SessionLogWatcher`가 두 프로바이더에 쓰이는데, Codex 쪽만 문제가 된 이유는 세 가지 차이 때문입니다.

**1. 폴더 규모가 다르다.** 전수 walk 비용은 파일 수·데이터 양(콜드 캐시)에 비례합니다.
- Claude `~/.claude/projects/<프로젝트>/` — 11,816개 / 3.8GB
- Codex `~/.codex/sessions/YYYY/MM/DD/` — 49,296개 / 19GB (세션마다 rollout 파일 1개 + `codex resume`가 옛 파일을 남겨 수개월치가 누적)

**2. Codex만 스캔 도중 락 경합이 겹친다.** Codex는 이벤트를 올바른 계정에 귀속시키려(`CodexStatusRouter`) 매 틱 `trackedFiles`를 읽는데, 이 접근이 스캔이 열거 내내 쥐고 있는 락과 부딪혀 스캔이 끝날 때까지 줄을 섭니다. Claude 워처에는 이런 라우터·접근이 없습니다.

**3. Codex는 이 스캔이 유일한 한도 데이터 출처다.** Claude 게이지는 usage HTTP 엔드포인트에서 오고(팝오버 열 때만, 캐시) 로그 스캔은 가끔 나는 한도 초과 *에러* 이벤트만 잡는 보조 경로입니다. Codex는 usage 엔드포인트가 없어 세션 로그의 `rate_limits`(매 턴 실림)가 게이지의 **유일한** 출처라, 스캔이 곧 게이지 갱신 경로 위에 놓입니다 — 그래서 스캔 지연이 드롭다운 반응 지연으로 바로 이어졌습니다.

**근거(수정 전 프로파일):** Codex 스캔+락대기 ≈ **4,449 샘플** vs Claude 스캔 **175 샘플** — Codex가 약 25배.

## 어떻게 고쳤나

폴더가 날짜별이라는 점을 이용합니다.
- **신규 세션 발견**: 최근 N일(Codex=7일) 날짜 폴더만 열거합니다.
- **이미 보던 세션**: 폴더 나이와 무관하게 그 파일만 직접 확인합니다 → 며칠 지난 세션을 `codex resume`으로 이어 써도 놓치지 않습니다.

Claude 스캔은 폴더 구조가 날짜별이 아니라(프로젝트별) 그대로 두었습니다 — 위 세 이유 모두 해당이 없어 손댈 필요가 없습니다.

## 결과 (실측, 제 환경)

| 지표 | 수정 전 | 수정 후 |
|---|---|---|
| 유휴 CPU (평균) | **19~21%** | **0.1%** |
| 매 스캔 열거 파일 수 | 49,296 | **7,494** (6.6배↓) |
| 최근 수정분 누락 | — | **0개** (실데이터로 확인) |
| `getattrlistbulk` 샘플 | 3702 | 108 |
| 스레드 / 메모리 | 6 / ~130MB | 4 / ~46MB |

## 트레이드오프 (의도적, 문서화)

첫 스캔(프라이밍)은 프루닝 없이 전수 열거해 **창 밖 옛 폴더의 최근 세션까지 시딩**하므로, 앱 재시작·오프라인 중 codex 사용 후 옛 세션을 resume해도 신호가 끊기지 않습니다(리뷰 반영). 남는 갭은 **"프라이밍 이후 실행 중 처음 resume되는 7일+ 옛 폴더 세션"** 하나뿐이며, 재시작하면 다시 시딩됩니다. 게다가 Codex 한도는 **계정 전역**이라 최근/활성 세션 이벤트로 교차 반영되므로 실질 영향은 거의 없습니다. 유닛 테스트로 이 경계를 고정했습니다.

## 안전성

- **OAuth refresh 트리거 변화 없음** — 계정 보호에 민감한 지점은 건드리지 않습니다.
- **UX/동작 변화 없음** — 순수 성능 수정. 스캔이 잡아내는 이벤트 집합은 (트레이드오프 항목을 제외하면) 동일합니다.
- 유닛 **165개 green**. 스캔 정확성 테스트: 옛 폴더의 추적 파일도 resume append를 tail / 프라이밍 전수 열거가 재시작 시 옛 폴더 최근 파일을 시딩 / 축소된 잔여(프라이밍 이후 첫 resume) 고정 / 당일 신규 파일 발견.
