### PR TITLE
fix: 계정 없는 프로바이더 탭 숨김 — 풀이 하나뿐이면 그 자리에 섹션 헤더

### DIFF
--- a/Sources/MobiusApp/Views/AccountListView.swift
+++ b/Sources/MobiusApp/Views/AccountListView.swift
@@ -14,9 +14,19 @@ extension Provider {
 }
 
 /// 팝오버 상단 필터 탭 — 전체 / Claude / Codex. rawValue가 AppStorage로 저장돼
-/// 마지막 선택이 재시작 후에도 유지된다.
+/// 마지막 선택이 재시작 후에도 유지된다. 실제로 노출되는 탭은 계정이 있는 풀로
+/// 한정되고(`AccountListView.visibleTabs`), 저장값이 그중에 없으면 읽을 때
+/// `.all`로 정규화된다(`AccountListView.tab`) — 저장값 자체는 보존한다.
 enum ProviderTab: String, CaseIterable {
     case all, claude, codex
+
+    /// 풀 → 탭. exhaustive switch라 새 Provider가 생기면 컴파일이 깨져 케이스 누락을 막는다.
+    init(provider: Provider) {
+        switch provider {
+        case .claude: self = .claude
+        case .codex: self = .codex
+        }
+    }
 
     var provider: Provider? {
         switch self {
@@ -48,7 +58,20 @@ struct AccountListView: View {
     @State private var rowHeights: [UUID: CGFloat] = [:]
     private let clock = Timer.publish(every: 30, on: .main, in: .common).autoconnect()
 
-    private var tab: ProviderTab { ProviderTab(rawValue: providerTabRaw) ?? .all }
+    /// ★ 저장된 선택이 지금 노출되는 탭에 없으면 `.all`로 **읽는다** — 저장값은 덮어쓰지 않는다.
+    /// 이 정규화가 없으면 탭 바가 숨겨진 뒤 저장값이 `codex`인 사용자가 "등록된 계정이 없습니다"
+    /// 화면에 갇힌다(탈출할 컨트롤이 화면에 없다). 저장값을 보존하므로 그 풀에 계정을 다시
+    /// 추가하면 원래 선택이 살아난다.
+    private var tab: ProviderTab {
+        let saved = ProviderTab(rawValue: providerTabRaw) ?? .all
+        guard !visibleTabs.isEmpty else { return .all }
+        return visibleTabs.contains(saved) ? saved : .all
+    }
+
+    /// 픽커는 정규화된 값을 읽고 쓰기는 원본으로 — 노출 탭이 바뀌어도 '선택 없음'이 안 생긴다.
+    private var tabSelection: Binding<String> {
+        Binding(get: { tab.rawValue }, set: { providerTabRaw = $0 })
+    }
 
     var body: some View {
         ZStack {
@@ -57,7 +80,16 @@ struct AccountListView: View {
                 if state.file.accounts.isEmpty {
                     emptyView
                 } else {
-                    tabBar
+                    // ★ 이 줄은 항상 존재한다 — 풀이 여럿이면 탭 바, 하나뿐이면 그 자리에
+                    // 섹션 헤더. 탭 바를 그냥 없애면 아래 카드가 위로 밀려 팝오버 레이아웃이
+                    // 흔들린다(사용자 피드백). 풀이 하나뿐일 때 탭은 고를 것이 없지만
+                    // "지금 어느 풀을 보고 있는가 + 그 풀의 자동 전환" 정보는 여전히 유효하므로,
+                    // 전체 탭이 쓰는 섹션 헤더를 그대로 재사용한다(새 UI 어휘 없음).
+                    if !visibleTabs.isEmpty {
+                        tabBar
+                    } else if let only = providersWithAccounts.first {
+                        sectionHeader(only)
+                    }
                     cards
                 }
                 footer
@@ -85,9 +117,9 @@ struct AccountListView: View {
             Text("Mobius").font(.system(size: 14, weight: .bold, design: .rounded))
             Text(loc("뫼비우스")).font(.system(size: 10)).foregroundStyle(.tertiary)
             Spacer()
-            // 풀 탭(또는 전체 탭인데 풀이 하나뿐)에서 그 풀의 자동 전환 토글 — 구 전역
-            // 토글과 같은 자리라 익숙하고, 탭 바가 한 줄을 온전히 쓸 수 있다(100% 폭).
-            // 전체 탭에서 풀이 여럿이면 각 섹션 헤더의 미니 토글이 담당한다(sectionHeader).
+            // 풀 탭에서 그 풀의 자동 전환 토글 — 구 전역 토글과 같은 자리라 익숙하고,
+            // 탭 바가 한 줄을 온전히 쓸 수 있다(100% 폭). 전체 탭이거나 풀이 하나뿐이면
+            // 각 섹션 헤더의 미니 토글이 담당한다(sectionHeader) — 토글은 늘 한 곳에만.
             if let provider = headerToggleProvider {
                 autoSwitchToggle(provider)
             }
@@ -106,29 +138,35 @@ struct AccountListView: View {
             .help(loc("한도가 차면 다음 계정으로 자동으로 이어집니다"))
     }
 
-    private var providersWithAccounts: [Provider] {
-        Provider.allCases.filter { !state.file.accounts(of: $0).isEmpty }
-    }
+    private var providersWithAccounts: [Provider] { state.file.providersWithAccounts }
 
-    /// 헤더 오른쪽 토글이 담당할 풀 — 풀 탭이면 그 풀, 전체 탭이면 풀이 하나뿐일 때만
-    /// 그 풀(섹션 헤더가 없어 토글 자리도 없으므로). 풀이 여럿인 전체 탭은 nil —
-    /// 각 섹션 헤더의 미니 토글이 담당한다.
-    private var headerToggleProvider: Provider? {
-        if let provider = tab.provider { return provider }
-        let pools = providersWithAccounts
-        return pools.count == 1 ? pools.first : nil
-    }
+    /// 헤더 오른쪽 토글이 담당할 풀 — 풀 탭일 때만 그 풀. 전체 탭이면 nil이고, 풀이
+    /// 하나뿐일 때도 nil이다(그때는 탭 바 자리의 섹션 헤더가 토글을 들고 있다).
+    /// 두 자리에 동시에 뜨면 같은 바인딩이 중복 노출된다 — 늘 한 곳에만.
+    private var headerToggleProvider: Provider? { tab.provider }
 
-    // MARK: 프로바이더 탭 바 — 100% 폭, 3등분 (자동 전환 토글은 헤더 오른쪽)
+    // MARK: 프로바이더 탭 바 — 100% 폭, 노출 탭 수만큼 균등 분할
+    // (자동 전환 토글은 풀 탭이면 헤더 오른쪽, 아니면 섹션 헤더)
 
     private func poolCount(_ t: ProviderTab) -> Int {
         t.provider.map { state.file.accounts(of: $0).count } ?? state.file.accounts.count
     }
 
+    /// 노출할 탭 — 계정이 있는 풀만. 풀이 하나뿐이면 **빈 배열**이다('전체' 탭과 그 풀 탭이
+    /// 같은 화면이라 고를 것이 없다). 그때 `body`는 이 자리에 `sectionHeader`를 대신 그리고,
+    /// `tab`이 `.all`로 읽히므로 `cards`의 '전체' 브랜치가 섹션 헤더 없이 그 풀만 그린다
+    /// (풀이 하나면 `cards`는 헤더를 안 그리므로 중복되지 않는다).
+    /// `providersWithAccounts`에서 파생되므로 프로바이더가 늘어도 자동으로 맞다.
+    private var visibleTabs: [ProviderTab] {
+        let pools = providersWithAccounts
+        guard pools.count > 1 else { return [] }
+        return [.all] + pools.map(ProviderTab.init(provider:))
+    }
+
     private var tabBar: some View {
-        PillPicker(options: ProviderTab.allCases.map {
+        PillPicker(options: visibleTabs.map {
             .init(value: $0.rawValue, label: $0.title, badge: poolCount($0))
-        }, selection: $providerTabRaw, fillsWidth: true)
+        }, selection: tabSelection, fillsWidth: true)
     }
 
     // MARK: 카드 목록
@@ -152,10 +190,12 @@ struct AccountListView: View {
         }
     }
 
-    /// 전체 탭의 풀 경계 — 대문자 레이블 + 오른쪽으로 흐르는 헤어라인 + 풀 자동 전환
-    /// 미니 토글. 맨글자 하나만 떠 있으면 길 잃은 텍스트처럼 보여서(사용자 피드백)
-    /// 디바이더로 "여기부터 이 풀"임을 고정하고, 전체 탭에서도 풀별 자동 전환 상태가
-    /// 보이고 조작 가능하게 한다 (풀 탭 헤더 토글과 짝 — 사각지대 제거).
+    /// 풀 경계 — 대문자 레이블 + 오른쪽으로 흐르는 헤어라인 + 풀 자동 전환 미니 토글.
+    /// 맨글자 하나만 떠 있으면 길 잃은 텍스트처럼 보여서(사용자 피드백) 디바이더로
+    /// "여기부터 이 풀"임을 고정하고, 풀별 자동 전환 상태가 보이고 조작 가능하게 한다
+    /// (풀 탭 헤더 토글과 짝 — 사각지대 제거).
+    /// 두 자리에서 쓰인다: (1) 전체 탭의 풀 섹션마다, (2) 풀이 하나뿐일 때 탭 바 자리
+    /// (탭이 사라져도 이 줄이 남아 아래 카드 위치가 흔들리지 않는다).
     private func sectionHeader(_ provider: Provider) -> some View {
         HStack(spacing: 8) {
             Text(provider.displayName.uppercased())

--- a/Sources/MobiusCore/Models.swift
+++ b/Sources/MobiusCore/Models.swift
@@ -277,6 +277,12 @@ public struct AccountsFile: Codable, Equatable, Sendable {
         accounts.filter { $0.provider == provider }
     }
 
+    /// 계정이 하나 이상 등록된 풀 — `Provider.allCases` 순서를 유지한다.
+    /// 팝오버의 탭 노출(계정 없는 프로바이더는 숨김)과 '전체' 탭 섹션이 공유한다.
+    public var providersWithAccounts: [Provider] {
+        Provider.allCases.filter { !accounts(of: $0).isEmpty }
+    }
+
     public func primary(of provider: Provider) -> AccountProfile? {
         accounts.first { $0.provider == provider }
     }

--- a/Tests/MobiusCoreTests/ProviderPoolTests.swift
+++ b/Tests/MobiusCoreTests/ProviderPoolTests.swift
@@ -67,6 +67,21 @@ final class ProviderPoolTests: XCTestCase {
         XCTAssertNil(file.active(of: .codex))
     }
 
+    /// 팝오버 탭 노출의 근거 — 계정이 있는 풀만 센다. 빈 풀 탭을 숨기고(계정 0개인
+    /// 프로바이더는 고를 것이 없다) 풀이 하나뿐이면 탭 바 자체를 없애는 판단에 쓰인다.
+    func testProvidersWithAccountsListsOnlyNonEmptyPoolsInDeclarationOrder() {
+        XCTAssertEqual(AccountsFile(accounts: []).providersWithAccounts, [])
+        XCTAssertEqual(AccountsFile(accounts: [profile("c1", .claude)])
+            .providersWithAccounts, [.claude])
+        // Claude가 비어도 Codex만 잡힌다 (한쪽 풀만 쓰는 사용자)
+        XCTAssertEqual(AccountsFile(accounts: [profile("x1", .codex)])
+            .providersWithAccounts, [.codex])
+        // 계정이 섞인 순서로 들어와도 Provider.allCases 순서를 따른다 —
+        // 탭 순서가 계정 추가 순서에 따라 흔들리면 안 된다
+        XCTAssertEqual(AccountsFile(accounts: [profile("x1", .codex), profile("c1", .claude)])
+            .providersWithAccounts, Provider.allCases)
+    }
+
     // MARK: AccountStore — (provider, email) 매칭과 풀별 상태
 
     func makeStore() throws -> AccountStore {


### PR DESCRIPTION
| as-is | to-be |
|--|--|
|<img width="459" height="389" alt="스크린샷 2026-08-07 오후 12 50 20" src="https://github.com/user-attachments/assets/c617fc8d-ce14-47f3-af94-d02af64781fe" /> | <img width="457" height="277" alt="스크린샷 2026-08-07 오후 12 45 54" src="https://github.com/user-attachments/assets/7fbfc3e3-bc50-4857-91c1-b5dd94fb063e" />|


## 문제

팝오버 탭 바가 `ProviderTab.allCases`로 구성돼(`AccountListView.swift:129`) **계정이 0개인 풀의 탭도 항상 노출**합니다. Claude만 쓰는 사용자에게 `[전체 2][Claude 2][Codex 0]`이 보이지만 실제로 고를 수 있는 화면은 하나뿐입니다.

같은 화면의 '전체' 탭 섹션은 이미 `providersWithAccounts`로 계정 있는 풀만 렌더하므로(`:143`), **한 화면 안에서 두 기준이 어긋나 있었습니다** — 탭 바만 필터링을 안 했습니다.

설정 화면(`SettingsView.swift:356`)은 로그인하는 자리이므로 모든 프로바이더가 보여야 맞다고 판단해 **그대로 뒀습니다.**

## 변경

| 계정 상태 | 탭 바 자리 | 카드 | 자동 전환 토글 |
|---|---|---|---|
| 0개 | 없음 | `emptyView` (기존) | 없음 |
| Claude 2 / Codex 0 | `CLAUDE ──── [토글]` | 카드 2장 | 섹션 헤더 |
| Claude 2 / Codex 1 | `[전체][Claude][Codex]` | 기존과 동일 | 기존과 동일 |
| 저장값=codex, Codex 0개 | `CLAUDE ──── [토글]` | Claude 카드 (갇힘 없음) | 섹션 헤더 |

- `visibleTabs` — 계정 있는 풀만 탭으로. 풀이 하나뿐이면 빈 배열.
- **탭 바를 그냥 없애지 않았습니다.** 없애면 아래 카드가 위로 밀려 팝오버 레이아웃이 흔들립니다. 그 자리에 기존 `sectionHeader`를 대신 그려 줄을 유지했습니다 — 새 UI 어휘 없이 '전체' 탭의 풀 경계 스타일을 그대로 재사용합니다.
- 자동 전환 토글은 **늘 한 곳에만**. 풀이 하나뿐이면 섹션 헤더가 들고 헤더 오른쪽은 비웁니다(`headerToggleProvider`가 `tab.provider`만 반환). 두 자리 모두 같은 `autoSwitchToggle`을 쓰므로 픽셀·바인딩이 동일합니다.

## ★ `tab` 정규화가 필수인 이유

`providerTab`은 `@AppStorage`로 영속되는데(`:42`) `tab`은 계정 유무를 검증하지 않았습니다(`:51`).

지금은 탭 3개가 항상 보여 Codex 탭에서 계정을 다 지워도 다른 탭으로 빠져나올 수 있습니다. 그런데 탭 바가 사라지면 **저장값이 `codex`인 사용자가 "등록된 계정이 없습니다" 화면에 갇힙니다** — 탈출할 컨트롤이 화면에 없습니다. 그래서 정규화는 부가 기능이 아니라 이 변경의 필수 구성요소입니다.

정규화는 **읽기 시점에만** 하고 저장값은 보존합니다. 덮어쓰면 Codex 계정을 잠시 지웠다 다시 추가했을 때 원래 탭 선택이 영구 소실되고, 뷰 업데이트 중 `@AppStorage` 쓰기는 "Modifying state during view update" 위험이 있습니다.

## 테스트

`providersWithAccounts`를 뷰의 private var에서 `AccountsFile`로 올렸습니다. `MobiusApp`이 `executableTarget`이라 테스트 타깃이 없어, 이 순수 로직이 유닛 테스트가 붙는 지점입니다. 계산 프로퍼티라 저장 스키마 변경이 아닙니다(실패 기록 13과 무관).

- `swift build` / `swift test` — 225개 통과
- 신규: `testProvidersWithAccountsListsOnlyNonEmptyPoolsInDeclarationOrder` (빈 풀 / 한쪽만 / 양쪽 / `Provider.allCases` 순서 유지)

**수동 QA** — `MOBIUS_HOME` 격리 + 합성 `accounts.json`(라이브 자격증명 무접촉)으로 진행:

- [x] Claude 2 / Codex 0 → 탭 바 자리에 `CLAUDE` 섹션 헤더, 카드 밀림 없음, 토글 단일 노출
- [ ] Claude 2 / Codex 1 → 탭 바 복귀 (회귀 확인)
- [ ] 저장값=codex + Codex 0개 → 갇힘 없음
- [ ] 저장값=codex + Codex 재추가 → Codex 탭 선택 복원
- [ ] 계정 0개 → `emptyView` 회귀
- [ ] 실패 기록 17 회귀 — primary 전환 시 List 스크롤 오프셋

미체크 항목은 확인 후 결과를 덧붙이겠습니다.

## 알려진 한계 / 논의 지점

**섹션 헤더 높이가 `PillPicker`와 픽셀 단위로 같지 않습니다.** `PillPicker`는 `.padding(3)` + 캡슐 배경이 있어 더 높습니다. 줄이 남아 있어 예전처럼 크게 밀리지는 않지만 약간의 차이는 있습니다. 측정 없이 `minHeight`를 박는 건 과적합이라 일부러 넣지 않았는데, 맞추는 게 좋다고 보시면 반영하겠습니다.

## 이슈 #8 (Anti-Gravity CLI) 상호작용

`visibleTabs`가 `providersWithAccounts`에서 파생되므로 프로바이더가 늘어도 자동으로 맞습니다. `ProviderTab.init(provider:)`는 exhaustive switch라 케이스 누락을 컴파일 타임에 잡습니다. 3개 중 2개만 계정이 있는 상황에서 저장값이 무효가 될 수 있는데, `tabSelection` 정규화가 픽커의 '선택 없음'도 함께 막습니다.