### PR TITLE
fix: 자격증명 blob이 4KB를 넘는 계정에서 계정 전환마다 키체인 암호창이 뜨던 문제 (실패 기록 12 재현 경로)

### DIFF
--- a/Sources/MobiusCore/KeychainClient.swift
+++ b/Sources/MobiusCore/KeychainClient.swift
@@ -65,6 +65,40 @@ public final class SystemKeychain: KeychainClient, @unchecked Sendable {
         }
     }
 
+    /// `security -i`가 한 번에 읽는 명령 한 줄의 상한(바이트, 개행 제외).
+    /// ★ 실측 2026-08-10: 4,096 B까지는 정상이지만 **4,097 B부터는 명령이 잘린 채
+    ///   그대로 실행되어** 항목에 truncated 값이 기록되고 exit 1이 난다
+    ///   (원본 "ORIGINAL-INTACT-VALUE" → 4,096 B 경계에서 잘린 쓰레기 값으로 덮어써짐).
+    ///   즉 "실패하면 원본이 남는다"가 아니라 **실패가 곧 손상**이므로,
+    ///   보내기 전에 길이를 미리 판정해 아예 시도하지 않는다.
+    static let interactiveCommandLimit = 4096
+
+    static func escapeForInteractive(_ s: String) -> String {
+        s.replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+    }
+
+    /// `security -i`에 보낼 명령 한 줄(개행 포함). 길이 판정과 실제 전송이 같은
+    /// 문자열을 쓰도록 순수 함수로 분리한다 — 어긋나면 가드가 무의미해진다.
+    static func interactiveWriteCommand(service: String, account: String,
+                                        value: String) -> String {
+        let s = escapeForInteractive(service)
+        let a = escapeForInteractive(account)
+        let v = escapeForInteractive(value)
+        return "add-generic-password -U -s \"\(s)\" -a \"\(a)\" -w \"\(v)\"\n"
+    }
+
+    /// 이 payload를 `security -i`로 안전하게 보낼 수 있는가.
+    /// 개행이 섞이면 명령이 두 줄로 쪼개지므로 그것도 여기서 함께 막는다.
+    static func fitsInteractiveCommand(service: String, account: String,
+                                       value: String) -> Bool {
+        if value.contains("\n") { return false }
+        let command = interactiveWriteCommand(service: service, account: account,
+                                              value: value)
+        // 개행 1바이트는 상한 밖이다 (실측: 개행 제외 4,096 B까지 통과).
+        return command.utf8.count - 1 <= interactiveCommandLimit
+    }
+
     public func write(service: String, account: String, data: Data) throws {
         // ★ SecItemUpdate/SecItemAdd로 쓰면 macOS가 항목의 파티션 리스트를 이 앱의
         //   cdhash로 도장 찍는다(re-stamp). 그러면 claude CLI와 Desktop 내장 Claude Code가
@@ -72,11 +106,21 @@ public final class SystemKeychain: KeychainClient, @unchecked Sendable {
         //   다음 쓰기에서 무효가 된다 (2026-07-11 실측 — CLAUDE.md 실패 기록 12).
         //   → 쓰기를 security CLI(-i, stdin 경유라 비밀이 argv에 안 남음)로 우회하면
         //   파티션이 apple-tool: 로 찍혀 claude 생태계 전체와 호환된다.
-        if let text = String(data: data, encoding: .utf8), !text.contains("\n"),
+        if let text = String(data: data, encoding: .utf8),
+           Self.fitsInteractiveCommand(service: service, account: account, value: text),
            writeViaSecurityCLI(service: service, account: account, value: text) {
             return
         }
-        // 폴백: 개행 포함/비UTF-8/CLI 실패 시 네이티브 경로 (파티션 도장은 감수)
+        // ★ payload가 `security -i` 한 줄 한계를 넘는 계정이 실재한다 — MCP 플러그인
+        //   OAuth 등록이 쌓이면 자격증명 blob이 486 B에서 8 KB로 불어난다(실측).
+        //   여기서 네이티브로 떨어지면 전환할 때마다 파티션이 깨져 실패 기록 12가
+        //   그대로 재현되므로, **같은 security 바이너리를 argv(-X 16진수)로** 호출한다.
+        //   도장은 그대로 apple-tool: 로 찍히고, 대가는 값이 잠깐 ps에 보이는 것뿐이다
+        //   (claude CLI 자신도 큰 payload엔 같은 형식을 쓴다).
+        if writeViaSecurityArgv(service: service, account: account, data: data) {
+            return
+        }
+        // 폴백: security 자체를 못 쓰는 경우에만 네이티브 (파티션 도장은 감수)
         let update = [kSecValueData as String: data]
         let status = SecItemUpdate(baseQuery(service, account) as CFDictionary,
                                    update as CFDictionary)
@@ -92,12 +136,11 @@ public final class SystemKeychain: KeychainClient, @unchecked Sendable {
 
     /// `security -i`(대화형 stdin)로 add-generic-password -U 실행. 성공 시 true.
     /// 비밀 값은 stdin으로만 전달되어 프로세스 인자(ps)에 노출되지 않는다.
+    /// **호출 전에 반드시 `fitsInteractiveCommand`로 길이를 확인할 것** — 한계를
+    /// 넘으면 실패가 아니라 손상이다(잘린 값이 기록된다).
     private func writeViaSecurityCLI(service: String, account: String, value: String) -> Bool {
-        func esc(_ s: String) -> String {
-            s.replacingOccurrences(of: "\\", with: "\\\\")
-                .replacingOccurrences(of: "\"", with: "\\\"")
-        }
-        let cmd = "add-generic-password -U -s \"\(esc(service))\" -a \"\(esc(account))\" -w \"\(esc(value))\"\n"
+        let cmd = Self.interactiveWriteCommand(service: service, account: account,
+                                               value: value)
         let p = Process()
         p.executableURL = URL(fileURLWithPath: "/usr/bin/security")
         p.arguments = ["-i"]
@@ -108,6 +151,25 @@ public final class SystemKeychain: KeychainClient, @unchecked Sendable {
         do { try p.run() } catch { return false }
         stdin.fileHandleForWriting.write(Data(cmd.utf8))
         stdin.fileHandleForWriting.closeFile()
+        p.waitUntilExit()
+        return p.terminationStatus == 0
+    }
+
+    /// `security add-generic-password -U … -X <hex>` (argv 경유). `-i` 한 줄 한계를
+    /// 넘는 payload 전용 우회로. 16진수라 이스케이프가 필요 없고 개행·비UTF-8
+    /// 바이트도 그대로 실을 수 있어, CLI 경로의 제약을 전부 우회한다.
+    /// 트레이드오프: 실행되는 짧은 순간 값이 `ps`에 보인다. 그래도 네이티브로
+    /// 떨어져 파티션을 깨뜨리는 것보다 낫다 — 파티션이 깨지면 claude CLI와
+    /// Desktop이 이후 **모든** 읽기에서 키체인 암호창을 띄운다.
+    private func writeViaSecurityArgv(service: String, account: String, data: Data) -> Bool {
+        let hex = data.map { String(format: "%02x", $0) }.joined()
+        let p = Process()
+        p.executableURL = URL(fileURLWithPath: "/usr/bin/security")
+        p.arguments = ["add-generic-password", "-U",
+                       "-s", service, "-a", account, "-X", hex]
+        p.standardOutput = FileHandle.nullDevice
+        p.standardError = FileHandle.nullDevice
+        do { try p.run() } catch { return false }
         p.waitUntilExit()
         return p.terminationStatus == 0
     }

--- a/Tests/MobiusCoreTests/KeychainClientTests.swift
+++ b/Tests/MobiusCoreTests/KeychainClientTests.swift
@@ -35,4 +35,69 @@ final class KeychainClientTests: XCTestCase {
         XCTAssertNoThrow(try kc.write(service: "target", account: "a", data: Data("t2".utf8)))
         XCTAssertEqual(try kc.read(service: "target", account: "a"), Data("t2".utf8))
     }
+
+    // MARK: - security -i 명령줄 길이 가드
+    //
+    // 한계를 넘으면 명령이 잘린 채 실행되어 항목에 truncated 값이 기록된다(실측).
+    // 즉 실패가 곧 손상이므로 보내기 전에 막아야 한다.
+
+    private let service = "Claude Code-credentials"
+    private let account = "tester"
+
+    /// 값을 뺀 명령 자체의 길이(개행 제외).
+    private var commandOverhead: Int {
+        SystemKeychain.interactiveWriteCommand(
+            service: service, account: account, value: ""
+        ).utf8.count - 1
+    }
+
+    func testTypicalCredentialBlobFitsInteractiveCommand() {
+        // MCP 등록이 없는 계정의 실제 blob 크기(실측 486 B)
+        let blob = String(repeating: "a", count: 486)
+        XCTAssertTrue(SystemKeychain.fitsInteractiveCommand(
+            service: service, account: account, value: blob))
+    }
+
+    func testBlobBloatedByMCPRegistrationsDoesNotFit() {
+        // MCP 플러그인 OAuth 등록이 쌓인 계정의 실제 blob 크기(실측 8,071 B).
+        // 이 경우가 막히지 않으면 잘린 값이 키체인에 기록된다.
+        let blob = String(repeating: "a", count: 8071)
+        XCTAssertFalse(SystemKeychain.fitsInteractiveCommand(
+            service: service, account: account, value: blob))
+    }
+
+    func testInteractiveCommandLimitBoundary() {
+        let exact = String(repeating: "x",
+                           count: SystemKeychain.interactiveCommandLimit - commandOverhead)
+        XCTAssertTrue(SystemKeychain.fitsInteractiveCommand(
+            service: service, account: account, value: exact),
+            "명령줄 정확히 \(SystemKeychain.interactiveCommandLimit) B는 통과해야 한다")
+        XCTAssertFalse(SystemKeychain.fitsInteractiveCommand(
+            service: service, account: account, value: exact + "x"),
+            "1 B만 넘어도 막아야 한다 — 넘기면 잘린 값이 기록된다")
+    }
+
+    func testEscapingCountsTowardTheLimit() {
+        // 따옴표·역슬래시는 이스케이프되어 2배가 되므로, 원문 길이가 아니라
+        // 이스케이프 후 길이로 판정해야 한다.
+        let budget = SystemKeychain.interactiveCommandLimit - commandOverhead
+        let quotes = String(repeating: "\"", count: budget / 2)
+        XCTAssertTrue(SystemKeychain.fitsInteractiveCommand(
+            service: service, account: account, value: quotes))
+        XCTAssertFalse(SystemKeychain.fitsInteractiveCommand(
+            service: service, account: account, value: quotes + "\""))
+    }
+
+    func testNewlineIsRejectedRegardlessOfLength() {
+        // 개행이 있으면 짧아도 명령이 두 줄로 쪼개져 뒷부분이 별도 명령이 된다.
+        XCTAssertFalse(SystemKeychain.fitsInteractiveCommand(
+            service: service, account: account, value: "short\nvalue"))
+    }
+
+    func testInteractiveCommandEscapesQuotesAndBackslashes() {
+        let command = SystemKeychain.interactiveWriteCommand(
+            service: "s", account: "a", value: #"q"b\c"#)
+        XCTAssertTrue(command.contains(#"-w "q\"b\\c""#), command)
+        XCTAssertTrue(command.hasSuffix("\n"))
+    }
 }


### PR DESCRIPTION
계정 전환할 때마다 키체인 암호창이 떠서 원인을 파다가, `SystemKeychain.write`의 CLI 경로가 실패했을 때 타는 폴백이 실패 기록 12를 그대로 재현한다는 걸 확인했습니다. 조건이 좀 특수하긴 한데 한번 걸리면 전환 기능을 아예 못 쓰게 되길래 고쳐 봤습니다.

### 증상

전환할 때마다 `security`가 요청하는 암호창이 뜹니다. '항상 허용'을 눌러도 다음 전환이면 도로 무효가 되고요. 실패 기록 12에 적힌 그 증상 그대로입니다.

실측 타임라인입니다 (2026-08-10, macOS 26.0 / Mobius 0.5.0).

```
17:07:05  계정 전환 → 파티션 [apple-tool:, teamid:LU6TMQQ8JT] → [teamid:LU6TMQQ8JT]
17:07:09  암호창 등장 (4초 후)
17:05~17:38  3초 간격 감시에서 400 샘플 중 327회 포착 (그 사이 쓰기는 0회)
```

### 원인은 `security -i`의 명령줄 길이 상한

`writeViaSecurityCLI`는 `security -i`의 stdin으로 명령을 한 줄에 담아 보내는데, 이 줄에 4,096 B 상한이 있습니다. 넘어가면 CLI 경로가 실패하고, 지금 코드는 그때 네이티브 `SecItemUpdate`로 내려갑니다. 파티션이 재도장되는 건 이 지점입니다.

service/account를 포함한 명령줄 전체 길이 기준으로 경계를 재 봤습니다 (개행 제외).

| 명령줄 | exit | 저장 결과 |
|---|---|---|
| 4,096 B | 0 | 정상 |
| 4,097 B | 1 | 4,096 B 경계에서 잘린 값이 기록됨 |

### ★ 파고 보니 실패가 아니라 손상이었습니다

상한을 넘으면 명령이 잘린 채로 그냥 실행됩니다. 원본이 남는 게 아니라 잘린 값이 덮어씁니다.

```
원본        : "ORIGINAL-INTACT-VALUE"
초과 쓰기   : exit=1
결과        : "ZZZZ…" 4,029 B      ← 원본 소멸
```

지금은 바로 뒤따르는 네이티브 폴백이 제 값을 다시 써 주니 결과적으로는 복구됩니다. 다만 그 폴백까지 실패하면 자격증명이 깨진 채로 남습니다.

### 어떤 계정이 4 KB를 넘나

Claude Code는 자격증명 blob 안에 `mcpOAuth`, 그러니까 MCP 서버 OAuth 등록 정보를 같이 넣어 둡니다. 공식 플러그인 마켓플레이스를 설치하면 한 번도 연결한 적 없는 서버 것까지 쌓입니다. `accessToken`이 빈 문자열인 채로요.

제 환경을 재 보니 이랬습니다.

```
전체 blob      : 8,071 B
  claudeAiOauth:   486 B   (실제 로그인 — 6%)
  mcpOAuth     : 7,326 B   (19개, 전부 미사용 — 91%)
```

19개 전부 `enabledPlugins`에 없는 고아 등록이었습니다. 486 B였으면 상한 근처도 못 갔을 텐데, 이것들이 blob을 16배로 불려서 두 배를 넘겨 버렸습니다.

### 수정

크게 두 가지를 했습니다.

먼저 보내기 전에 명령줄 길이를 재서(`fitsInteractiveCommand`) 상한을 넘으면 아예 `-i`로 보내지 않습니다. 잘린 쓰기가 애초에 일어나지 않게 막는 거죠. 개행이 섞인 경우도 여기서 같이 걸러 냅니다. 명령이 두 줄로 쪼개지면 뒷부분이 별도 명령이 되어 버리니까요.

그다음, 상한을 넘는 payload는 네이티브로 내려보내는 대신 argv(`-X` 16진수)로 우회합니다. 결국 같은 `security` 바이너리라 도장은 그대로 `apple-tool:`로 찍힙니다. 16진수라 이스케이프도 필요 없고 개행이나 비UTF-8 바이트도 안전하게 실립니다.

길이를 재는 쪽과 실제로 보내는 쪽이 같은 문자열을 쓰도록 명령 생성은 순수 함수로 빼 뒀습니다. 두 곳이 어긋나면 가드가 아무 의미가 없어서요. 네이티브 경로는 `security` 자체를 못 쓸 때의 최후 수단으로만 남습니다.

### 트레이드오프

argv 경로는 프로세스가 도는 짧은 순간 값이 `ps`에 보입니다. 그래도 이쪽이 낫다고 봤습니다.

파티션이 깨지면 claude CLI와 Desktop이 그 뒤로 모든 읽기에서 암호창을 띄웁니다. 반면 노출 창은 서브프로세스 수명인 수 ms고, 같은 사용자 세션 안에서만 보입니다. claude CLI 자신도 payload가 크면 같은 방식으로 넘어갑니다.

```
Keychain payload (${n}B JSON) exceeds security -i stdin limit; using argv
```

4 KB 이하는 기존 `-i` 경로 그대로라 대다수 사용자에겐 동작 변화가 없습니다.

### 테스트

`KeychainClientTests`에 6개 붙였고 전체 230개 통과합니다.

- 일반 blob(486 B)은 통과, MCP 누적 blob(8,071 B)은 차단
- 경계: 정확히 4,096 B는 통과, 1 B만 넘으면 차단
- 이스케이프된 길이로 판정하는지 (따옴표는 2배가 되므로)
- 개행은 길이와 무관하게 차단
- 명령 문자열의 따옴표·역슬래시 이스케이프

`SystemKeychain`은 실제 키체인을 건드려서 단위 테스트가 어렵길래, 판정 로직만 순수 함수로 떼어 내 검증했습니다.

### 검증

패치와 별개로, 제 환경에서 미사용 `mcpOAuth` 19개를 지워 blob을 8,071 B에서 523 B로 줄인 다음 전환을 왕복시켜 봤습니다.

```
계정 A → 계정 B   파티션 [apple-tool:] 유지, 암호창 없음
계정 B → 계정 A   파티션 [apple-tool:] 유지, 암호창 없음
```

수정 전에는 전환마다 예외 없이 깨졌습니다. 이 PR은 blob을 줄이지 않은 사용자도 같은 결과를 얻게 합니다.

### 환경

macOS 26.0 (Darwin 25.6.0) / Apple Swift 6.3.3 / Mobius 0.5.0 (512abfa)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
