### PR TITLE
fix(security): usage 조회가 URLSession.shared를 써서 액세스 토큰이 디스크 캐시에 평문으로 남던 문제

### DIFF
--- a/Sources/MobiusCore/UsageFetcher.swift
+++ b/Sources/MobiusCore/UsageFetcher.swift
@@ -60,6 +60,23 @@ public enum UsageFetcherError: Error, Equatable {
 public enum UsageFetcher {
     public static let endpoint = URL(string: "https://api.anthropic.com/api/oauth/usage")!
 
+    /// ★ `URLSession.shared`를 쓰면 안 된다 — 공유 세션은 **디스크 URLCache**를 물고 있어
+    ///   요청이 직렬화되어 `~/Library/Caches/dev.chussum.mobius/Cache.db`에 저장되고,
+    ///   거기에 `Authorization: Bearer <액세스 토큰>` 헤더가 **평문으로 남는다**.
+    ///   실측 2026-08-10: `Cache.db-wal`에서 실제 액세스 토큰 13개 발견(파일 0644,
+    ///   디렉터리 0755). 그중 1개는 당시 유효한 토큰이었고, 나머지는 회전·전환으로
+    ///   밀려난 과거 계정 토큰들이었다.
+    ///   키체인은 접근 시 ACL 승인을 요구하지만 `~/Library/Caches`는 TCC 보호 대상이
+    ///   아니라, 같은 사용자로 실행되는 아무 프로세스나 승인 없이 읽어간다 —
+    ///   앱이 키체인으로 지키던 것을 캐시가 우회로로 흘리는 셈이다.
+    ///   → TokenRefresher·CodexUsageFetcher·CodexTokenRefresher와 동일하게
+    ///   ephemeral 세션을 쓴다(디스크에 아무것도 안 남음).
+    static let session: URLSession = {
+        let cfg = URLSessionConfiguration.ephemeral
+        cfg.urlCache = nil
+        return URLSession(configuration: cfg)
+    }()
+
     /// Claude Code 자격증명 blob(JSON)에서 access token 추출
     public static func accessToken(from keychainBlob: Data) -> String? {
         guard let obj = try? JSONSerialization.jsonObject(with: keychainBlob) as? [String: Any]
@@ -149,7 +166,7 @@ public enum UsageFetcher {
         req.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
         req.setValue("oauth-2025-04-20", forHTTPHeaderField: "anthropic-beta")
         req.timeoutInterval = 10
-        let (data, resp) = try await URLSession.shared.data(for: req)
+        let (data, resp) = try await session.data(for: req)
         guard let http = resp as? HTTPURLResponse else { return nil }
         if http.statusCode == 401 || http.statusCode == 403 {
             throw UsageFetcherError.unauthorized

--- a/Tests/MobiusCoreTests/UsageFetcherTests.swift
+++ b/Tests/MobiusCoreTests/UsageFetcherTests.swift
@@ -118,4 +118,20 @@ final class UsageFetcherTests: XCTestCase {
                        Date(timeIntervalSince1970: 1_783_785_648))
         XCTAssertNil(UsageFetcher.expiresAt(from: Data("{}".utf8)))
     }
+
+    /// usage 요청에는 `Authorization: Bearer <액세스 토큰>` 헤더가 실린다. 세션에 디스크
+    /// URLCache가 붙어 있으면 그 요청이 직렬화되어 `~/Library/Caches/<번들ID>/Cache.db`에
+    /// 저장되고 토큰이 평문으로 남는다(실측 2026-08-10: 액세스 토큰 13개, 파일 0644).
+    /// 이 테스트는 그 회귀를 막는다.
+    func testSessionKeepsNothingOnDisk() {
+        let cfg = UsageFetcher.session.configuration
+        XCTAssertNil(cfg.urlCache,
+                     "URLCache가 붙으면 Authorization 헤더가 디스크 Cache.db에 평문으로 남는다")
+        // ephemeral 세션의 쿠키 저장소는 nil이 아니라 **메모리 전용 인스턴스**다.
+        // 따라서 nil 여부가 아니라 공유 저장소와 다른지로 확인해야 한다.
+        XCTAssertFalse(cfg.httpCookieStorage === HTTPCookieStorage.shared,
+                       "공유 쿠키 저장소를 쓰면 디스크에 남는다")
+        // URLSession.shared는 디스크 캐시를 물고 있으므로 절대 쓰면 안 된다.
+        XCTAssertFalse(UsageFetcher.session === URLSession.shared)
+    }
 }


### PR DESCRIPTION
키체인 승인창 건(#10)을 파다가 별개의 문제를 하나 더 발견해서 같이 올립니다. 이쪽은 보안 이슈입니다.

### 무슨 일이 벌어지나

`UsageFetcher.fetch`가 `URLSession.shared`를 씁니다. 공유 세션은 디스크 `URLCache`를 물고 있어서, 요청이 직렬화된 채 `~/Library/Caches/<번들ID>/Cache.db`에 저장됩니다. 그런데 이 요청에는 `Authorization: Bearer <액세스 토큰>` 헤더가 붙어 있죠. 결과적으로 **토큰이 평문으로 디스크에 남습니다.**

제 환경에서 실제로 재 봤습니다.

```
~/Library/Caches/<번들ID>/Cache.db-wal
  파일 권한   : 0644   (디렉터리 0755)
  실제 토큰   : 13개   (전부 sk-ant-oat01-, 108자, 엔트로피 5.31~5.57)
  그중 1개    : 그 시점 유효한 액세스 토큰과 SHA-256 지문 일치
```

13개나 쌓인 건 계정을 전환할 때마다 새 토큰으로 usage를 조회하기 때문입니다. 회전되거나 전환으로 밀려난 과거 계정 토큰들이 캐시에 그대로 누적됩니다.

### 왜 문제인가

키체인은 접근할 때 ACL 승인을 요구합니다. 그런데 `~/Library/Caches`는 TCC 보호 대상이 아닙니다. **같은 사용자로 실행되는 아무 프로세스나 승인 없이 이 파일을 읽어갑니다.** 앱이 키체인으로 애써 지키던 값이 캐시라는 뒷문으로 새는 구조입니다.

심각도를 정확히 적자면, 캐시에 있던 13개는 **전부 액세스 토큰**이고 리프레시 토큰(`sk-ant-ort01-`)은 없었습니다. 액세스 토큰은 만료되면 끝이라 새 토큰을 발급받는 데는 못 씁니다. 파국은 아니지만, 유효 기간 안에는 계정 API를 그대로 쓸 수 있습니다.

### 수정

`TokenRefresher`, `CodexUsageFetcher`, `CodexTokenRefresher`는 **이미 ephemeral 세션을 쓰고 있었습니다.** usage 경로만 빠져 있었네요. 같은 패턴으로 맞췄습니다.

```swift
static let session: URLSession = {
    let cfg = URLSessionConfiguration.ephemeral
    cfg.urlCache = nil
    return URLSession(configuration: cfg)
}()
```

ephemeral은 캐시·쿠키·자격증명을 전부 메모리에만 두므로 디스크에 아무것도 안 남습니다. `urlCache = nil`은 메모리 캐시까지 끄는 것이라 명시적으로 붙였습니다.

### 테스트

`UsageFetcherTests`에 회귀 테스트 1개 추가, 전체 225개 통과합니다.

세션 설정에 `urlCache`가 붙어 있지 않은지, 공유 쿠키 저장소를 쓰지 않는지, `URLSession.shared`가 아닌지를 확인합니다. 참고로 ephemeral 세션의 쿠키 저장소는 `nil`이 아니라 **메모리 전용 인스턴스**라, nil 여부가 아니라 공유 저장소와 다른지로 봐야 합니다(처음에 nil로 단언했다가 테스트가 잡아 줬습니다).

### 이미 캐시가 쌓인 사용자

패치가 나가도 기존 캐시는 스스로 사라지지 않습니다. SQLite WAL이라 앱이 체크포인트하기 전까지 남습니다. 릴리스 노트에 한 줄 안내가 있으면 좋겠습니다.

```bash
osascript -e 'quit app "Mobius"'
rm -rf ~/Library/Caches/dev.chussum.mobius
```

캐시에 유효한 토큰이 남아 있었다면 지우는 것만으로는 부족하고, 이미 열려 있던 창은 닫히지 않으니 재로그인으로 회전시키는 편이 안전합니다.

### 환경

macOS 26.0 (Darwin 25.6.0) / Apple Swift 6.3.3 / Mobius 0.5.0 (512abfa)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
