### PR TITLE
refactor: 비활성 계정 게이지 갱신 루프를 코어로 추출 — 프로바이더 어댑터 주입

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,10 @@ Sources/MobiusCore/       앱·CLI 공유 코어 (전부 의존성 주입 → �
   RateLimitParser.swift    Claude 세션 로그 rate-limit 이벤트 파서 (실측 기반)
   CodexRateLimitParser.swift Codex rate_limits 상태 파서 (매 턴 in-band, 게이지+소진 판정)
   CodexStatusRouter.swift  Codex 상태의 계정 귀속 — 전환 전 세션 파일 격리 (오염 방지 ★아래)
+  InactiveGaugeRefresher.swift 비활성 계정 게이지 갱신 공용 루프 — 만료 판정 → refresh →
+                           credential lock 안 원자 검증 저장 → usage 조회. 프로바이더별 능력은
+                           InactiveGaugeProvider 어댑터로 주입 (게이지 전용: 아무것도 마킹 안 함)
+  CodexGaugeAdapter.swift  Codex용 InactiveGaugeProvider 조립 (AuthBlob+TokenRefresher+UsageProber)
   SessionLogWatcher.swift  세션 로그 tail — (루트, 파서, 정책) 주입 제네릭 (네트워크 0)
   AutoSwitchEngine.swift   순수 상태머신, 풀당 1인스턴스 (쿨다운/마진/autoSwitchedFromPrimary,
                            on/off는 풀별 autoSwitchByProvider — 기록 없는 풀은 켬; 모델스코프 pin)

--- a/Sources/MobiusApp/AppState.swift
+++ b/Sources/MobiusApp/AppState.swift
@@ -21,18 +21,19 @@ final class AppState: ObservableObject {
     // 백그라운드에서. 완료되면 nil로 정착(실제 activeAccountID가 인계).
     @Published private(set) var pendingSwitchID: UUID?
     private var usageTask: Task<Void, Never>?
-    // 비활성 codex 게이지 프로브 — 단일 플라이트 핸들 + 순수 조회기. 게이지 전용(마킹 없음).
-    private var codexUsageTask: Task<Void, Never>?
-    private let codexProber = CodexUsageProber()
-    // 비활성 codex 계정의 만료 access 토큰 refresh(게이지 전용) — 회전본은 credential lock 안에서
-    // 활성 재확인·신원 검증 후 원자 저장한다. 활성 계정은 절대 refresh하지 않는다.
-    private let codexRefresher = CodexTokenRefresher()
-    // transient(네트워크/5xx) 실패 시 팝오버마다 회전 시도가 반복되지 않게 하는 계정당 재시도 쿨다운.
-    private var lastCodexRefreshAttemptAt: [UUID: Date] = [:]
-    // refresh_token_invalidated/invalid_grant(죽은 토큰) 계정의 긴 백오프 — 죽은 토큰은 어차피 401
-    // 이므로 이 시각 전까지 refresh/probe를 아예 건너뛴다(게이지는 마지막 값에 둔다).
-    private var codexRefreshDeadUntil: [UUID: Date] = [:]
-    static let codexDeadRefreshCooldown: TimeInterval = 24 * 3600
+    // 비활성 계정 게이지 갱신 — 프로바이더당 단일 플라이트 Task + 코어의 공용 루프
+    // (InactiveGaugeRefresher: 만료 판정 → refresh → 원자 검증 저장 → probe). 게이지 전용
+    // (마킹 없음)이며, 프로바이더가 늘어나도 어댑터 하나와 아래 항목 한 줄만 추가하면 된다.
+    private var gaugeTasks: [Provider: Task<Void, Never>] = [:]
+    private lazy var gaugeRefreshers: [Provider: InactiveGaugeRefresher] = [
+        .codex: InactiveGaugeRefresher(adapter: CodexGaugeAdapter(io: codexIO),
+                                       store: store,
+                                       retryCooldown: Self.usageRefreshRetryCooldown,
+                                       deadRefreshCooldown: Self.deadGaugeRefreshCooldown),
+    ]
+    // refresh 토큰이 폐기된(죽은) 계정의 긴 백오프 — 어차피 401이므로 이 시각 전까지
+    // refresh/probe를 아예 건너뛴다(게이지는 마지막 값에 둔다).
+    static let deadGaugeRefreshCooldown: TimeInterval = 24 * 3600
     private var usageCacheLoaded = false
     private static let usageCacheKey = "usageCacheV1"
 
@@ -421,106 +422,55 @@ final class AppState: ObservableObject {
         }
     }
 
-    /// codex 전환 직전, 진행 중인 비활성 게이지 refresh를 정지·완료대기시킨다 — 전환↔회전 HTTP
-    /// 창(케이스2: 왕복 중 전환)을 닫는다. cancel()은 루프의 다음 계정 진입을 막아, 대기를 현재 처리
-    /// 중인 계정의 진행 중 HTTP(refresh 후 probe까지 최대 2회 순차) 완료까지로 바운드한다.
-    private func quiesceCodexUsageTask() async {
-        codexUsageTask?.cancel()
-        await codexUsageTask?.value
+    /// 전환 직전, 그 프로바이더의 진행 중인 비활성 게이지 refresh를 정지·완료대기시킨다 —
+    /// 전환↔회전 HTTP 창(케이스2: 왕복 중 전환)을 닫는다. cancel()은 루프의 다음 계정 진입을 막아,
+    /// 대기를 현재 처리 중인 계정의 진행 중 HTTP(refresh 후 probe까지 최대 2회 순차) 완료까지로
+    /// 바운드한다.
+    private func quiesceGaugeTask(for provider: Provider) async {
+        gaugeTasks[provider]?.cancel()
+        await gaugeTasks[provider]?.value
     }
 
-    /// 팝오버가 열릴 때 호출 — **비활성 codex** 계정의 게이지를 네트워크로 조회한다(Claude의
-    /// refreshUsageIfStale와 대칭). 활성 codex 계정은 세션 로그 in-band 경로(tick의
+    /// 팝오버가 열릴 때 호출 — 비활성 codex 계정 게이지 갱신(뷰가 부르는 이름 유지).
+    func refreshCodexUsageIfStale() { refreshInactiveGauges(for: .codex) }
+
+    /// 팝오버가 열릴 때 호출 — **비활성** 계정의 게이지를 네트워크로 조회한다(Claude의
+    /// refreshUsageIfStale와 대칭). 활성 계정은 프로바이더별 in-band 경로(codex는 tick의
     /// processCodexBatches)가 그대로 담당하므로 제외한다 — processCodexBatches는 손대지 않는다.
     ///
     /// ★ **게이지 전용**: usage 캐시(usage[id])만 채운다. setNeedsReauth·엔진·rateLimit 기록을
-    /// 절대 호출하지 않고(CodexUsageProber의 안전 계약), 자격증명은 저장 스냅샷 바이트를 읽기
-    /// 전용으로만 쓴다(쓰기/refresh/codex 실행 없음). 401은 만료된 비활성 토큰이라 무해하게
-    /// 게이지를 stale로 둔다. wham/usage는 codex가 이미 폴링하는 상태 엔드포인트라 추가 쿼터
-    /// 부담이 없어(B1), showUsageGauges와 함께 기본 활성이다(별도 토글 없음 — Claude와 대칭).
+    /// 절대 호출하지 않고(InactiveGaugeProvider의 안전 계약), 자격증명은 저장 스냅샷 바이트를
+    /// 읽기 전용으로만 쓴다(만료 시 게이지를 되살리는 refresh만 예외이며, 회전본은 credential
+    /// lock 안에서 활성 재확인·신원 검증 후에만 저장된다). 401은 만료된 비활성 토큰이라 무해하게
+    /// 게이지를 stale로 둔다. codex의 wham/usage는 codex가 이미 폴링하는 상태 엔드포인트라 추가
+    /// 쿼터 부담이 없어(B1), showUsageGauges와 함께 기본 활성이다(별도 토글 없음 — Claude와 대칭).
     /// 신선도/쿨다운 기준은 usage[id].fetchedAt(영속됨) — 재시작 후에도 엔드포인트를 난타하지 않는다.
-    func refreshCodexUsageIfStale() {
+    private func refreshInactiveGauges(for provider: Provider) {
         loadUsageCacheIfNeeded()
         guard UserDefaults.standard.object(forKey: "showUsageGauges") == nil
                 || UserDefaults.standard.bool(forKey: "showUsageGauges") else { return }
-        guard codexUsageTask == nil else { return }
+        guard let refresher = gaugeRefreshers[provider] else { return }
+        guard gaugeTasks[provider] == nil else { return }
         let now = Date()
-        let codexActiveID = store.file.activeByProvider[.codex]
-        // 비활성 codex 계정 중 게이지 캐시가 만료된 것만. 활성은 로그 경로가 담당하므로 제외.
-        let stale = store.file.accounts.filter {
-            $0.provider == .codex && $0.id != codexActiveID &&
-            (usage[$0.id]?.fetchedAt ?? .distantPast) < now.addingTimeInterval(-usageStaleness)
-        }
-        guard !stale.isEmpty else { return }
-        codexUsageTask = Task { @MainActor in
-            defer { codexUsageTask = nil }
-            var updated = false
-            for profile in stale {
-                if Task.isCancelled { break }
-                // 죽은 토큰 계정은 긴 백오프 동안 refresh/probe를 아예 건너뛴다(어차피 401 → 무의미).
-                if let deadUntil = codexRefreshDeadUntil[profile.id], now < deadUntil { continue }
-                // 저장된 auth.json 스냅샷 바이트를 읽는다. refresh 성공 시 아래에서 회전본으로 교체.
-                guard let authJSON = try? store.secretData(for: profile.id) else { continue }
-                var probeBytes = authJSON
-
-                // 저장 access 토큰이 이미 만료됐으면 게이지를 못 읽어 얼어붙는다(GET엔 회전이 없어
-                // 만료 토큰으로 조회하면 401만 받는다) → refresh로 미리 되살린다. **활성 계정은 절대
-                // refresh하지 않는다**(락 밖 fresh-read로 활성/전환중 계정을 재확인).
-                let liveActiveID = store.file.activeByProvider[.codex]
-                if profile.id != liveActiveID, profile.id != pendingSwitchID,
-                   let exp = CodexAuthBlob.accessTokenExpiry(fromAuthJSON: authJSON), exp <= now {
-                    // 계정당 쿨다운: 최근 시도가 있으면 이번 라운드는 건너뛴다(만료 토큰이라 게이지도
-                    // 어차피 못 읽는다). 첫 시도는 게이팅 안 됨(distantPast)이라 프리즈 해소는 유지.
-                    guard now.timeIntervalSince(lastCodexRefreshAttemptAt[profile.id] ?? .distantPast)
-                            >= Self.usageRefreshRetryCooldown else { continue }
-                    lastCodexRefreshAttemptAt[profile.id] = now
-                    let refreshOutcome = await Task { await codexRefresher.refresh(authJSON: authJSON) }.value
-                    switch refreshOutcome {
-                    case .refreshed(let rotated):
-                        // ★ 원자 capture: credential lock 안에서 (1) 활성 재확인(TOCTOU — 그 사이
-                        //   자동/수동 전환으로 활성이 됐으면 라이브 ~/.codex가 authoritative이므로
-                        //   회전본을 버린다), (2) 신원/형태 검증(실패 기록 1/13 클래스: 손상·타 계정
-                        //   바이트가 스냅샷을 덮어쓰지 않게), (3) 원자 저장. 하나라도 어긋나면 기존
-                        //   스냅샷을 보존한다(덮어쓰지 않음).
-                        let stored: Data? = store.withCredentialLock(profile.id) { () -> Data? in
-                            guard profile.id != store.file.activeByProvider[.codex] else { return nil }
-                            // 락 안에서 스냅샷을 다시 읽는다 — HTTP 왕복 중 adopt/재로그인이 끼면
-                            // 신규 로그인 스냅샷을 구 세션 회전본으로 덮는 edge를 차단(회전본 폐기).
-                            guard let current = try? store.secretData(for: profile.id),
-                                  current == authJSON else { return nil }
-                            guard codexIO.recognizesSecret(rotated),
-                                  CodexConfigIO.email(fromAuthJSON: rotated) == profile.emailAddress,
-                                  CodexTokenRefresher.refreshToken(fromAuthJSON: rotated)?.isEmpty == false
-                            else { return nil }
-                            do { try store.setSecretData(rotated, for: profile.id) } catch { return nil }
-                            return rotated
-                        }
-                        guard let stored else { continue }   // 활성이 됨 / 검증 실패 — 이번 라운드 스킵
-                        probeBytes = stored
-                        lastCodexRefreshAttemptAt[profile.id] = nil   // 성공 — 쿨다운 해제
-                        codexRefreshDeadUntil[profile.id] = nil
-                    case .invalidated:
-                        // 죽은 refresh 토큰(세션 종료) — 게이지 전용 방화벽: 엔진/persisted reauth를
-                        // 절대 건드리지 않고, 긴 백오프(codexRefreshDeadUntil)만 남기고 stale로 둔다.
-                        codexRefreshDeadUntil[profile.id] = now.addingTimeInterval(Self.codexDeadRefreshCooldown)
-                        continue
-                    case .transient:
-                        // refresh POST는 위 Task {} 쉴드로 취소 비전파라 여기는 순수 네트워크/5xx다
-                        // (우리 자신의 취소로 인한 transient는 이 분기에 도달할 수 없다).
-                        continue   // 쿨다운 뒤 재시도(게이지는 마지막 값 유지)
-                    }
-                }
-
-                // B1 게이지 조회 — (가능하면 갱신된) 바이트로. 읽기 전용, 아무것도 마킹하지 않는다.
-                switch await codexProber.probe(authJSON: probeBytes, now: now) {
-                case .usage(let snap):
-                    usage[profile.id] = snap
-                    updated = true
-                case .stale, .transient:
-                    continue   // 게이지를 마지막 스냅샷에 둔다 — 아무것도 마킹하지 않는다.
-                }
+        let activeID = store.file.activeByProvider[provider]
+        // 비활성 계정 중 게이지 캐시가 만료된 것만. 활성은 in-band 경로가 담당하므로 제외.
+        let targets = store.file.accounts
+            .filter {
+                $0.provider == provider && $0.id != activeID &&
+                (usage[$0.id]?.fetchedAt ?? .distantPast) < now.addingTimeInterval(-usageStaleness)
             }
-            if updated { saveUsageCache() }
+            .map { InactiveGaugeRefresher.Target(id: $0.id, emailAddress: $0.emailAddress) }
+        guard !targets.isEmpty else { return }
+        gaugeTasks[provider] = Task { @MainActor in
+            defer { gaugeTasks[provider] = nil }
+            let updated = await refresher.refreshRound(
+                targets: targets,
+                now: now,
+                // ★ 매 계정마다 새로 읽는다 — 루프가 도는 사이 자동/수동 전환으로 활성이 바뀔 수 있다.
+                activeID: { self.store.file.activeByProvider[provider] },
+                excludedID: { self.pendingSwitchID },
+                onUsage: { id, snap in self.usage[id] = snap })
+            if !updated.isEmpty { saveUsageCache() }
         }
     }
 
@@ -1140,7 +1090,7 @@ final class AppState: ObservableObject {
                 guard await preflightFallback(id, now: now) else { file = store.file; return }
             }
             let fromID = store.file.activeByProvider[provider]
-            if provider == .codex { await quiesceCodexUsageTask() }
+            if provider == .codex { await quiesceGaugeTask(for: provider) }
             do {
                 try switcher.switchTo(id)
                 engines[provider]?.noteSwitched(now: now)
@@ -1203,7 +1153,7 @@ final class AppState: ObservableObject {
                 pendingSwitchID = id
                 Task { @MainActor in
                     defer { pendingSwitchID = nil }
-                    await quiesceCodexUsageTask()
+                    await quiesceGaugeTask(for: .codex)
                     performSwitch(to: id)
                 }
             } else {

--- a/Sources/MobiusApp/AppState.swift
+++ b/Sources/MobiusApp/AppState.swift
@@ -25,15 +25,15 @@ final class AppState: ObservableObject {
     // (InactiveGaugeRefresher: 만료 판정 → refresh → 원자 검증 저장 → probe). 게이지 전용
     // (마킹 없음)이며, 프로바이더가 늘어나도 어댑터 하나와 아래 항목 한 줄만 추가하면 된다.
     private var gaugeTasks: [Provider: Task<Void, Never>] = [:]
-    private lazy var gaugeRefreshers: [Provider: InactiveGaugeRefresher] = [
-        .codex: InactiveGaugeRefresher(adapter: CodexGaugeAdapter(io: codexIO),
-                                       store: store,
-                                       retryCooldown: Self.usageRefreshRetryCooldown,
-                                       deadRefreshCooldown: Self.deadGaugeRefreshCooldown),
-    ]
-    // refresh 토큰이 폐기된(죽은) 계정의 긴 백오프 — 어차피 401이므로 이 시각 전까지
-    // refresh/probe를 아예 건너뛴다(게이지는 마지막 값에 둔다).
-    static let deadGaugeRefreshCooldown: TimeInterval = 24 * 3600
+    // 키는 어댑터의 provider에서 유도한다 — 키와 어댑터가 어긋날 여지를 아예 없앤다.
+    private lazy var gaugeRefreshers: [Provider: InactiveGaugeRefresher] = {
+        let all = [
+            InactiveGaugeRefresher(adapter: CodexGaugeAdapter(io: codexIO),
+                                   store: store,
+                                   retryCooldown: Self.usageRefreshRetryCooldown),
+        ]
+        return Dictionary(uniqueKeysWithValues: all.map { ($0.provider, $0) })
+    }()
     private var usageCacheLoaded = false
     private static let usageCacheKey = "usageCacheV1"
 
@@ -1153,7 +1153,7 @@ final class AppState: ObservableObject {
                 pendingSwitchID = id
                 Task { @MainActor in
                     defer { pendingSwitchID = nil }
-                    await quiesceGaugeTask(for: .codex)
+                    await quiesceGaugeTask(for: provider)
                     performSwitch(to: id)
                 }
             } else {

--- a/Sources/MobiusCore/CodexGaugeAdapter.swift
+++ b/Sources/MobiusCore/CodexGaugeAdapter.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+/// Codex의 `InactiveGaugeProvider` 구현 — 비활성 codex 계정의 게이지를 되살린다.
+/// 기존 부품(`CodexAuthBlob` / `CodexTokenRefresher` / `CodexUsageProber` / `CodexConfigIO`)을
+/// 그대로 조립만 한다. 판정 로직은 여기서 새로 만들지 않는다.
+///
+/// 활성 codex 계정은 세션 로그 in-band 경로(`AppState.processCodexBatches`)가 담당하므로
+/// 이 어댑터의 대상이 아니다. `wham/usage`는 codex가 이미 폴링하는 상태 엔드포인트라 추가
+/// 쿼터 부담이 없다.
+public struct CodexGaugeAdapter: InactiveGaugeProvider {
+    public let provider = Provider.codex
+
+    private let io: CodexConfigIO
+    private let refresher: CodexTokenRefresher
+    private let prober: CodexUsageProber
+
+    public init(io: CodexConfigIO,
+                refresher: CodexTokenRefresher = CodexTokenRefresher(),
+                prober: CodexUsageProber = CodexUsageProber()) {
+        self.io = io
+        self.refresher = refresher
+        self.prober = prober
+    }
+
+    public func accessTokenExpiry(fromSecret secret: Data) -> Date? {
+        CodexAuthBlob.accessTokenExpiry(fromAuthJSON: secret)
+    }
+
+    public func refresh(secret: Data) async -> InactiveGaugeRefreshOutcome {
+        switch await refresher.refresh(authJSON: secret) {
+        case .refreshed(let rotated): return .refreshed(rotated)
+        case .invalidated:            return .invalidated
+        case .transient:              return .transient
+        }
+    }
+
+    /// 형태 인식 + 신원 일치 + 비어있지 않은 refresh 토큰. 셋 중 하나라도 어긋나면 회전본을
+    /// 버린다 — 손상·타 계정 바이트가 스냅샷을 덮어쓰는 실패 클래스(실패 기록 1/13)를 막는다.
+    public func acceptsRotatedSecret(_ rotated: Data, forEmail email: String) -> Bool {
+        io.recognizesSecret(rotated)
+            && CodexConfigIO.email(fromAuthJSON: rotated) == email
+            && CodexTokenRefresher.refreshToken(fromAuthJSON: rotated)?.isEmpty == false
+    }
+
+    public func probeUsage(secret: Data, now: Date) async -> InactiveGaugeProbeOutcome {
+        switch await prober.probe(authJSON: secret, now: now) {
+        case .usage(let snap): return .usage(snap)
+        case .stale:           return .stale
+        case .transient:       return .transient
+        }
+    }
+}

--- a/Sources/MobiusCore/InactiveGaugeRefresher.swift
+++ b/Sources/MobiusCore/InactiveGaugeRefresher.swift
@@ -62,6 +62,11 @@ extension AccountStore: GaugeSecretStore {}
 /// TOCTOU 재확인·capture-or-nothing 저장 같은 **자격증명 안전 불변식이 테스트 밖에** 있었고,
 /// 세 번째 프로바이더는 이 120여 줄을 통째로 복제해야 했다. 코어로 끌어내려 두 문제를 함께 푼다.
 ///
+/// `@MainActor`인 것은 의도다 — 이 루프는 원래 `AppState`(메인 액터)에서 돌았고, `AccountStore`의
+/// credential lock은 **동기** NSLock이라 `Switcher.switchTo`와 같은 액터에서 상호배제될 때만
+/// 의미가 있다. 실행 컨텍스트를 옮기면 그 락 순서 계약이 함께 바뀌므로 이 PR에서는 건드리지 않았다
+/// (스냅샷 읽기/쓰기는 계정당 수 KB로, 기존과 동일한 비용이다).
+///
 /// 대상은 **비활성 계정만**이다 — 활성 계정을 refresh하면 실행 중인 CLI 세션이 메모리에 든
 /// 시작 시점 토큰이 서버 회전으로 무효화된다(클로버 → 세션 파괴). 호출측이 활성/전환중 계정을
 /// 걸러 넘기고, 이 루프가 저장 직전 credential lock 안에서 **다시** 확인한다.
@@ -136,7 +141,8 @@ public final class InactiveGaugeRefresher {
                 // ★ 취소 쉴드: refresh POST는 서버에서 refresh 토큰을 **회전**시킨다. 왕복 중에
                 //   취소되면 회전본을 못 받아 저장 스냅샷의 구 토큰이 죽고 계정이 벽돌이 된다.
                 //   자식 Task로 감싸 상위 취소가 전파되지 않게 한다.
-                let outcome = await Task { await self.adapter.refresh(secret: secret) }.value
+                let adapter = self.adapter   // 쉴드 Task가 self를 잡지 않도록 값만 캡처
+                let outcome = await Task { await adapter.refresh(secret: secret) }.value
                 switch outcome {
                 case .refreshed(let rotated):
                     // ★ 원자 capture: credential lock 안에서 (1) 활성 재확인(TOCTOU — 그 사이
@@ -179,10 +185,10 @@ public final class InactiveGaugeRefresher {
         return updated
     }
 
-    // MARK: 테스트 관찰용 (백오프가 실제로 걸렸는지)
+    // MARK: 테스트 관찰용 (백오프가 실제로 걸렸는지) — 공개 API 아님(@testable로만 보인다)
 
     /// 죽은 토큰 백오프가 걸린 시각 — 이 시각 전까지는 refresh/probe를 건너뛴다.
-    public func deadBackoffUntil(_ id: UUID) -> Date? { deadUntil[id] }
+    func deadBackoffUntil(_ id: UUID) -> Date? { deadUntil[id] }
     /// 마지막 refresh 시도 시각 — 성공하면 해제(nil)된다.
-    public func lastRefreshAttempt(_ id: UUID) -> Date? { lastRefreshAttemptAt[id] }
+    func lastRefreshAttempt(_ id: UUID) -> Date? { lastRefreshAttemptAt[id] }
 }

--- a/Sources/MobiusCore/InactiveGaugeRefresher.swift
+++ b/Sources/MobiusCore/InactiveGaugeRefresher.swift
@@ -62,10 +62,12 @@ extension AccountStore: GaugeSecretStore {}
 /// TOCTOU 재확인·capture-or-nothing 저장 같은 **자격증명 안전 불변식이 테스트 밖에** 있었고,
 /// 세 번째 프로바이더는 이 120여 줄을 통째로 복제해야 했다. 코어로 끌어내려 두 문제를 함께 푼다.
 ///
-/// `@MainActor`인 것은 의도다 — 이 루프는 원래 `AppState`(메인 액터)에서 돌았고, `AccountStore`의
-/// credential lock은 **동기** NSLock이라 `Switcher.switchTo`와 같은 액터에서 상호배제될 때만
-/// 의미가 있다. 실행 컨텍스트를 옮기면 그 락 순서 계약이 함께 바뀌므로 이 PR에서는 건드리지 않았다
-/// (스냅샷 읽기/쓰기는 계정당 수 KB로, 기존과 동일한 비용이다).
+/// `@MainActor`는 **기존 실행 컨텍스트를 그대로 보존한 것**이다 — 이 루프는 `AppState`(메인 액터)
+/// 안에 있었고, 호출측이 활성 계정 판정을 동기 클로저로 넘긴다. 스냅샷 읽기/쓰기가 메인 스레드에서
+/// 도는 것도 기존과 같다(계정당 수 KB). 다른 컨텍스트로 옮기는 것은 `activeID` 조회의 동기 계약부터
+/// 바꿔야 하는 별개 변경이라 이 PR에서는 하지 않았다.
+/// (`AccountStore`의 credential lock은 NSLock이라 어느 스레드에서 쥐어도 상호배제된다 — 액터 선택과
+/// 무관하다. 여기서 @MainActor를 고른 이유는 락이 아니라 위의 호출 계약이다.)
 ///
 /// 대상은 **비활성 계정만**이다 — 활성 계정을 refresh하면 실행 중인 CLI 세션이 메모리에 든
 /// 시작 시점 토큰이 서버 회전으로 무효화된다(클로버 → 세션 파괴). 호출측이 활성/전환중 계정을
@@ -96,10 +98,18 @@ public final class InactiveGaugeRefresher {
 
     public var provider: Provider { adapter.provider }
 
+    /// refresh 토큰이 폐기된(죽은) 계정의 긴 백오프 — 어차피 401이므로 이 시각 전까지
+    /// refresh/probe를 아예 건너뛴다. 게이지 전용 상수라 이 컴포넌트가 단일 출처다.
+    /// `nonisolated` — 기본 인자 표현식은 비격리 문맥에서 평가된다(Swift 6에서는 오류).
+    nonisolated public static let defaultDeadRefreshCooldown: TimeInterval = 24 * 3600
+
+    /// - Parameters:
+    ///   - retryCooldown: transient 실패 후 계정당 재시도 간격. 호출측(AppState)이 Claude 경로와
+    ///     같은 값을 쓰므로 주입받는다.
     public init(adapter: any InactiveGaugeProvider,
                 store: any GaugeSecretStore,
                 retryCooldown: TimeInterval,
-                deadRefreshCooldown: TimeInterval) {
+                deadRefreshCooldown: TimeInterval = InactiveGaugeRefresher.defaultDeadRefreshCooldown) {
         self.adapter = adapter
         self.store = store
         self.retryCooldown = retryCooldown
@@ -149,7 +159,15 @@ public final class InactiveGaugeRefresher {
                     //   전환으로 활성이 됐으면 라이브 자격증명이 authoritative이므로 회전본을
                     //   버린다), (2) 스냅샷 재확인(HTTP 왕복 중 adopt/재로그인이 끼면 신규 로그인
                     //   스냅샷을 구 세션 회전본으로 덮는 edge 차단), (3) 신원/형태 검증, (4) 원자
-                    //   저장. 하나라도 어긋나면 기존 스냅샷을 **보존**한다(덮어쓰지 않음).
+                    //   저장. 하나라도 어긋나면 저장 스냅샷을 **덮어쓰지 않는다**.
+                    //   ★ 단, "덮어쓰지 않음"이 곧 무해는 아니다 — 200을 받은 시점에 서버측 회전은
+                    //     이미 커밋돼 구 refresh 토큰이 소비된 상태다. 회전본을 버리면 스냅샷에는
+                    //     소비된 토큰이 남아 다음 라운드가 .invalidated를 받고 24시간 백오프로 들어간다
+                    //     (게이지만 얼고, 게이지 전용 방화벽이라 아무것도 마킹하지 않는다). 그래서 이
+                    //     경로에 도달하는 빈도 자체를 호출측이 줄인다 — 전환 진입 시 quiesce, 매 계정
+                    //     활성 fresh-read, 그리고 refresh POST의 취소 쉴드.
+                    //     저장 실패(4번)도 같은 결과가 되며, 게이지 경로에는 Claude의 .storeFailed →
+                    //     needsReauth 같은 복구 표면이 없다(마킹 금지가 이 컴포넌트의 계약이다).
                     let stored: Data? = store.withCredentialLock(id) { () -> Data? in
                         guard id != activeID() else { return nil }
                         guard let current = try? store.secretData(for: id), current == secret

--- a/Sources/MobiusCore/InactiveGaugeRefresher.swift
+++ b/Sources/MobiusCore/InactiveGaugeRefresher.swift
@@ -1,0 +1,188 @@
+import Foundation
+
+/// 비활성 계정 게이지 갱신에 필요한 **프로바이더별 능력**. `InactiveGaugeRefresher`가 이 네 가지만
+/// 보고 "만료 판정 → (필요하면) refresh → 원자 검증 저장 → usage 조회" 루프를 돌린다.
+///
+/// ★ **게이지 전용 방화벽**(CLAUDE.md: Codex 재인증 자동 감지는 의도적으로 미구현):
+/// 이 프로토콜의 어떤 구현도 `setNeedsReauth`·`AutoSwitchEngine`·`rateLimit` 기록을 유발해선
+/// 안 된다. 실패는 전부 "게이지를 마지막 값에 둔다"로 끝난다 — 시끄러운 401이 자동 전환의
+/// 폴백 후보를 죽이면 안 되기 때문이다.
+public protocol InactiveGaugeProvider: Sendable {
+    var provider: Provider { get }
+
+    /// 저장 스냅샷 바이트에서 access 토큰 만료를 읽는다. 못 읽으면 nil — 만료 판정을 건너뛰고
+    /// 그냥 조회한다(401은 무해하게 stale로 끝난다).
+    func accessTokenExpiry(fromSecret secret: Data) -> Date?
+
+    /// 만료된 스냅샷을 되살린다. 200이면 회전본 바이트를 돌려주고, 그 외에는 아무것도 돌려주지
+    /// 않는다(기존 스냅샷 보존 — 회전 토큰 유실 방지의 capture-or-nothing 계약).
+    func refresh(secret: Data) async -> InactiveGaugeRefreshOutcome
+
+    /// 회전본을 저장 스냅샷으로 받아들여도 되는가. **credential lock 안에서 동기로 호출**되므로
+    /// 네트워크·파일 접근 없는 순수 판정이어야 한다(형태 인식 + 신원 일치 + refresh 토큰 존재).
+    func acceptsRotatedSecret(_ rotated: Data, forEmail email: String) -> Bool
+
+    /// 사용량 조회. **읽기 전용** — 자격증명을 쓰지 않고 토큰을 회전시키지 않는다.
+    func probeUsage(secret: Data, now: Date) async -> InactiveGaugeProbeOutcome
+}
+
+/// 게이지 전용 refresh 결과. 재인증(needsReauth) 케이스가 없다 — 죽은 토큰도 마킹이 아니라
+/// 긴 백오프로만 처리한다.
+public enum InactiveGaugeRefreshOutcome: Equatable, Sendable {
+    /// 200 — 회전된 토큰을 반영한 새 스냅샷 바이트. 호출측이 (활성 재확인 + 검증 후) 원자 저장한다.
+    case refreshed(Data)
+    /// refresh 토큰 폐기(세션 종료) — refresh로는 되살릴 수 없다. 아무것도 마킹하지 않고
+    /// 긴 쿨다운으로 물러난다.
+    case invalidated
+    /// 네트워크/5xx/기타 — 일시적. 죽음으로 단정하지 않고 다음 기회에 재시도.
+    case transient
+}
+
+/// 게이지 전용 조회 결과. 어떤 실패도 계정을 죽었다고 마킹하지 않는다.
+public enum InactiveGaugeProbeOutcome: Equatable, Sendable {
+    case usage(UsageSnapshot)   // 200 — 게이지 갱신
+    case stale                  // 401/403 또는 만료 토큰 — 게이지를 마지막 값에 둔다(무해)
+    case transient              // 네트워크/일시 오류 — 다음 기회에 재시도
+}
+
+/// `InactiveGaugeRefresher`가 쓰는 비밀 스냅샷 저장소의 최소 계약. `AccountStore`가 그대로
+/// 만족하며, 테스트는 인메모리 구현을 넣어 네트워크·파일 없이 루프를 검증한다.
+public protocol GaugeSecretStore: AnyObject, Sendable {
+    func secretData(for id: UUID) throws -> Data?
+    func setSecretData(_ data: Data, for id: UUID) throws
+    @discardableResult
+    func withCredentialLock<T>(_ id: UUID, _ body: () throws -> T) rethrows -> T
+}
+
+extension AccountStore: GaugeSecretStore {}
+
+/// **비활성 계정 게이지 갱신 루프** — 프로바이더 어댑터 하나만 갈아끼우면 재사용된다.
+///
+/// 원래 이 루프는 `AppState`(테스트 타깃이 없는 `MobiusApp`)에 Codex 전용으로 인라인돼 있었다.
+/// TOCTOU 재확인·capture-or-nothing 저장 같은 **자격증명 안전 불변식이 테스트 밖에** 있었고,
+/// 세 번째 프로바이더는 이 120여 줄을 통째로 복제해야 했다. 코어로 끌어내려 두 문제를 함께 푼다.
+///
+/// 대상은 **비활성 계정만**이다 — 활성 계정을 refresh하면 실행 중인 CLI 세션이 메모리에 든
+/// 시작 시점 토큰이 서버 회전으로 무효화된다(클로버 → 세션 파괴). 호출측이 활성/전환중 계정을
+/// 걸러 넘기고, 이 루프가 저장 직전 credential lock 안에서 **다시** 확인한다.
+@MainActor
+public final class InactiveGaugeRefresher {
+    /// 갱신 대상 — 게이지 루프에 필요한 최소 정보만 옮긴다(프로필 전체를 끌고 오지 않는다).
+    public struct Target: Equatable, Sendable {
+        public var id: UUID
+        /// 회전본 신원 검증의 기준값. 다른 계정의 바이트가 스냅샷을 덮어쓰는 것을 막는다.
+        public var emailAddress: String
+        public init(id: UUID, emailAddress: String) {
+            self.id = id
+            self.emailAddress = emailAddress
+        }
+    }
+
+    private let adapter: any InactiveGaugeProvider
+    private let store: any GaugeSecretStore
+    private let retryCooldown: TimeInterval
+    private let deadRefreshCooldown: TimeInterval
+
+    /// 계정당 refresh 재시도 쿨다운 기록 — transient 실패가 팝오버마다 회전 시도로 반복되는 것을 막는다.
+    /// 첫 시도는 게이팅되지 않으므로(distantPast) 게이지 프리즈 해소는 그대로 유지된다.
+    private var lastRefreshAttemptAt: [UUID: Date] = [:]
+    /// 죽은 refresh 토큰 계정의 긴 백오프 — 어차피 401이라 refresh/probe를 아예 건너뛴다.
+    private var deadUntil: [UUID: Date] = [:]
+
+    public var provider: Provider { adapter.provider }
+
+    public init(adapter: any InactiveGaugeProvider,
+                store: any GaugeSecretStore,
+                retryCooldown: TimeInterval,
+                deadRefreshCooldown: TimeInterval) {
+        self.adapter = adapter
+        self.store = store
+        self.retryCooldown = retryCooldown
+        self.deadRefreshCooldown = deadRefreshCooldown
+    }
+
+    /// 한 라운드 실행. 호출측 Task 안에서 돌며, 취소되면 **다음 계정으로 진입하지 않는다** —
+    /// 대기는 현재 계정의 진행 중 HTTP(refresh 후 probe까지 최대 2회 순차) 완료까지로 바운드된다.
+    ///
+    /// - Parameters:
+    ///   - targets: 비활성 + 게이지 캐시 만료 계정 (호출측이 걸러 넘긴다).
+    ///   - activeID: **매 계정마다 새로 읽는** 라이브 활성 계정 — 루프가 도는 사이 자동/수동
+    ///     전환으로 활성이 바뀔 수 있다(TOCTOU).
+    ///   - excludedID: 전환이 진행 중이라 건드리면 안 되는 계정(낙관적 표시 중인 대상).
+    ///   - onUsage: 계정 하나가 끝날 때마다 **즉시** 호출된다 — 라운드가 끝날 때까지 기다리지
+    ///     않고 게이지가 하나씩 차오르게 하기 위한 것(기존 UI 동작 유지).
+    /// - Returns: 갱신에 성공한 계정별 usage 스냅샷. 호출측이 영속 여부를 판단한다.
+    public func refreshRound(targets: [Target],
+                             now: Date,
+                             activeID: () -> UUID?,
+                             excludedID: () -> UUID?,
+                             onUsage: (UUID, UsageSnapshot) -> Void = { _, _ in }) async
+                             -> [UUID: UsageSnapshot] {
+        var updated: [UUID: UsageSnapshot] = [:]
+        for target in targets {
+            if Task.isCancelled { break }
+            let id = target.id
+            if let until = deadUntil[id], now < until { continue }
+            guard let secret = try? store.secretData(for: id) else { continue }
+            var probeBytes = secret
+
+            // 저장 access 토큰이 이미 만료됐으면 게이지를 못 읽어 얼어붙는다(GET엔 회전이 없어
+            // 만료 토큰으로 조회하면 401만 받는다) → refresh로 미리 되살린다.
+            if id != activeID(), id != excludedID(),
+               let exp = adapter.accessTokenExpiry(fromSecret: secret), exp <= now {
+                guard now.timeIntervalSince(lastRefreshAttemptAt[id] ?? .distantPast) >= retryCooldown
+                else { continue }
+                lastRefreshAttemptAt[id] = now
+                // ★ 취소 쉴드: refresh POST는 서버에서 refresh 토큰을 **회전**시킨다. 왕복 중에
+                //   취소되면 회전본을 못 받아 저장 스냅샷의 구 토큰이 죽고 계정이 벽돌이 된다.
+                //   자식 Task로 감싸 상위 취소가 전파되지 않게 한다.
+                let outcome = await Task { await self.adapter.refresh(secret: secret) }.value
+                switch outcome {
+                case .refreshed(let rotated):
+                    // ★ 원자 capture: credential lock 안에서 (1) 활성 재확인(TOCTOU — 그 사이
+                    //   전환으로 활성이 됐으면 라이브 자격증명이 authoritative이므로 회전본을
+                    //   버린다), (2) 스냅샷 재확인(HTTP 왕복 중 adopt/재로그인이 끼면 신규 로그인
+                    //   스냅샷을 구 세션 회전본으로 덮는 edge 차단), (3) 신원/형태 검증, (4) 원자
+                    //   저장. 하나라도 어긋나면 기존 스냅샷을 **보존**한다(덮어쓰지 않음).
+                    let stored: Data? = store.withCredentialLock(id) { () -> Data? in
+                        guard id != activeID() else { return nil }
+                        guard let current = try? store.secretData(for: id), current == secret
+                        else { return nil }
+                        guard adapter.acceptsRotatedSecret(rotated, forEmail: target.emailAddress)
+                        else { return nil }
+                        do { try store.setSecretData(rotated, for: id) } catch { return nil }
+                        return rotated
+                    }
+                    guard let stored else { continue }   // 활성이 됨 / 검증 실패 — 이번 라운드 스킵
+                    probeBytes = stored
+                    lastRefreshAttemptAt[id] = nil       // 성공 — 쿨다운 해제
+                    deadUntil[id] = nil
+                case .invalidated:
+                    deadUntil[id] = now.addingTimeInterval(deadRefreshCooldown)
+                    continue
+                case .transient:
+                    // refresh POST는 위 취소 쉴드 덕에 여기 도달하는 transient가 순수 네트워크/5xx다
+                    // (우리 자신의 취소로 인한 transient는 이 분기에 올 수 없다).
+                    continue                              // 쿨다운 뒤 재시도(게이지는 마지막 값 유지)
+                }
+            }
+
+            // 게이지 조회 — (가능하면 갱신된) 바이트로. 읽기 전용, 아무것도 마킹하지 않는다.
+            switch await adapter.probeUsage(secret: probeBytes, now: now) {
+            case .usage(let snap):
+                updated[id] = snap
+                onUsage(id, snap)
+            case .stale, .transient:
+                continue                                  // 게이지를 마지막 스냅샷에 둔다
+            }
+        }
+        return updated
+    }
+
+    // MARK: 테스트 관찰용 (백오프가 실제로 걸렸는지)
+
+    /// 죽은 토큰 백오프가 걸린 시각 — 이 시각 전까지는 refresh/probe를 건너뛴다.
+    public func deadBackoffUntil(_ id: UUID) -> Date? { deadUntil[id] }
+    /// 마지막 refresh 시도 시각 — 성공하면 해제(nil)된다.
+    public func lastRefreshAttempt(_ id: UUID) -> Date? { lastRefreshAttemptAt[id] }
+}

--- a/Tests/MobiusCoreTests/InactiveGaugeRefresherTests.swift
+++ b/Tests/MobiusCoreTests/InactiveGaugeRefresherTests.swift
@@ -1,0 +1,363 @@
+import XCTest
+@testable import MobiusCore
+
+// 픽스처는 파일 스코프에 둔다 — @Sendable 스텁 클로저 안에서 쓰이므로 액터 격리 밖이어야 한다.
+private let fixedNow = Date(timeIntervalSince1970: 1_700_000_000)
+private let accountID = UUID()
+private let accountEmail = "dev@corp.com"
+private let freshSecret = Data("fresh-token".utf8)
+private let rotatedSecret = Data("rotated-token".utf8)
+
+private func makeSnapshot(_ percent: Double) -> UsageSnapshot {
+    UsageSnapshot(fiveHourPercent: percent, fiveHourResetsAt: nil,
+                  sevenDayPercent: nil, sevenDayResetsAt: nil, fetchedAt: fixedNow)
+}
+
+/// 비활성 게이지 루프의 자격증명 안전 불변식 검증. 이 루프는 원래 `AppState`(테스트 타깃 없는
+/// MobiusApp)에 인라인돼 있어 TOCTOU 재확인·capture-or-nothing 저장이 전부 테스트 밖에 있었다.
+/// 코어로 내려온 지금은 네트워크·파일 없이 전부 재현한다.
+@MainActor
+final class InactiveGaugeRefresherTests: XCTestCase {
+
+    // MARK: 테스트 더블
+
+    /// 인메모리 비밀 스냅샷 저장소. `withCredentialLock` 안에서 무엇을 읽고 썼는지 관찰한다.
+    final class FakeStore: GaugeSecretStore, @unchecked Sendable {
+        var secrets: [UUID: Data] = [:]
+        var writes: [(UUID, Data)] = []
+        /// 락 진입 시점에 호출 — "HTTP 왕복 중 스냅샷이 바뀌는" 상황을 주입한다.
+        var onLockEnter: (() -> Void)?
+
+        func secretData(for id: UUID) throws -> Data? { secrets[id] }
+
+        func setSecretData(_ data: Data, for id: UUID) throws {
+            secrets[id] = data
+            writes.append((id, data))
+        }
+
+        @discardableResult
+        func withCredentialLock<T>(_ id: UUID, _ body: () throws -> T) rethrows -> T {
+            onLockEnter?()
+            return try body()
+        }
+    }
+
+    /// 프로바이더 어댑터 스텁 — 만료/refresh/검증/probe를 전부 주입한다.
+    struct FakeAdapter: InactiveGaugeProvider {
+        let provider = Provider.codex
+        var expiry: @Sendable (Data) -> Date?
+        var refreshResult: @Sendable (Data) async -> InactiveGaugeRefreshOutcome
+        var accepts: @Sendable (Data, String) -> Bool = { _, _ in true }
+        var probeResult: @Sendable (Data) async -> InactiveGaugeProbeOutcome
+
+        func accessTokenExpiry(fromSecret secret: Data) -> Date? { expiry(secret) }
+        func refresh(secret: Data) async -> InactiveGaugeRefreshOutcome { await refreshResult(secret) }
+        func acceptsRotatedSecret(_ rotated: Data, forEmail email: String) -> Bool { accepts(rotated, email) }
+        func probeUsage(secret: Data, now: Date) async -> InactiveGaugeProbeOutcome { await probeResult(secret) }
+    }
+
+    // MARK: 픽스처
+
+    let now = fixedNow
+    let id = accountID
+    let email = accountEmail
+    var target: InactiveGaugeRefresher.Target { .init(id: id, emailAddress: email) }
+
+    let fresh = freshSecret
+    let rotated = rotatedSecret
+
+    /// 관찰용 카운터를 공유하기 위한 참조 상자 (스텁이 struct라 값 캡처가 안 되므로).
+    final class Counters: @unchecked Sendable {
+        var refreshCalls = 0
+        var probedBytes: [Data] = []
+    }
+
+    private func makeRefresher(store: FakeStore,
+                               counters: Counters,
+                               expired: Bool,
+                               refresh: @escaping @Sendable (Data) async -> InactiveGaugeRefreshOutcome
+                                   = { _ in .transient },
+                               accepts: @escaping @Sendable (Data, String) -> Bool = { _, _ in true },
+                               probe: @escaping @Sendable (Data) async -> InactiveGaugeProbeOutcome
+                                   = { _ in .stale },
+                               retryCooldown: TimeInterval = 600) -> InactiveGaugeRefresher {
+        let expiryDate = expired ? now.addingTimeInterval(-60) : now.addingTimeInterval(3600)
+        let adapter = FakeAdapter(
+            expiry: { _ in expiryDate },
+            refreshResult: { secret in counters.refreshCalls += 1; return await refresh(secret) },
+            accepts: accepts,
+            probeResult: { secret in counters.probedBytes.append(secret); return await probe(secret) })
+        return InactiveGaugeRefresher(adapter: adapter, store: store,
+                                      retryCooldown: retryCooldown,
+                                      deadRefreshCooldown: 24 * 3600)
+    }
+
+    // MARK: 만료되지 않은 토큰 — refresh 없이 조회만
+
+    func testFreshTokenSkipsRefreshAndProbesStoredBytes() async {
+        let store = FakeStore(); store.secrets[id] = fresh
+        let counters = Counters()
+        let sut = makeRefresher(store: store, counters: counters, expired: false,
+                                probe: { _ in .usage(makeSnapshot(12)) })
+
+        let updated = await sut.refreshRound(targets: [target], now: now,
+                                             activeID: { nil }, excludedID: { nil })
+
+        XCTAssertEqual(counters.refreshCalls, 0, "만료 전에는 회전시키지 않는다")
+        XCTAssertEqual(counters.probedBytes, [fresh])
+        XCTAssertEqual(updated[id]?.fiveHourPercent, 12)
+        XCTAssertTrue(store.writes.isEmpty, "게이지 조회만으로 스냅샷을 쓰지 않는다")
+    }
+
+    // MARK: 활성/전환중 계정은 절대 refresh하지 않는다 (클로버 방지)
+
+    func testActiveAccountIsNeverRefreshed() async {
+        let store = FakeStore(); store.secrets[id] = fresh
+        let counters = Counters()
+        let sut = makeRefresher(store: store, counters: counters, expired: true,
+                                refresh: { _ in .refreshed(rotatedSecret) })
+
+        _ = await sut.refreshRound(targets: [target], now: now,
+                                   activeID: { accountID }, excludedID: { nil })
+
+        XCTAssertEqual(counters.refreshCalls, 0, "활성 계정 refresh = 실행 중 세션 파괴")
+        XCTAssertTrue(store.writes.isEmpty)
+    }
+
+    func testPendingSwitchTargetIsNeverRefreshed() async {
+        let store = FakeStore(); store.secrets[id] = fresh
+        let counters = Counters()
+        let sut = makeRefresher(store: store, counters: counters, expired: true,
+                                refresh: { _ in .refreshed(rotatedSecret) })
+
+        _ = await sut.refreshRound(targets: [target], now: now,
+                                   activeID: { nil }, excludedID: { accountID })
+
+        XCTAssertEqual(counters.refreshCalls, 0, "전환 진행 중인 계정은 건드리지 않는다")
+    }
+
+    // MARK: 만료 → refresh 성공 → 회전본 저장 후 그 바이트로 조회
+
+    func testExpiredTokenRefreshesStoresRotatedAndProbesWithIt() async {
+        let store = FakeStore(); store.secrets[id] = fresh
+        let counters = Counters()
+        let sut = makeRefresher(store: store, counters: counters, expired: true,
+                                refresh: { _ in .refreshed(rotatedSecret) },
+                                probe: { _ in .usage(makeSnapshot(40)) })
+
+        let updated = await sut.refreshRound(targets: [target], now: now,
+                                             activeID: { nil }, excludedID: { nil })
+
+        XCTAssertEqual(counters.refreshCalls, 1)
+        XCTAssertEqual(store.secrets[id], rotated, "회전본이 원자 저장돼야 한다")
+        XCTAssertEqual(counters.probedBytes, [rotated], "조회는 갱신된 바이트로")
+        XCTAssertEqual(updated[id]?.fiveHourPercent, 40)
+        XCTAssertNil(sut.lastRefreshAttempt(id), "성공하면 재시도 쿨다운이 해제된다")
+    }
+
+    // MARK: TOCTOU — HTTP 왕복 중 그 계정이 활성이 되면 회전본을 버린다
+
+    func testRotatedSecretDiscardedWhenAccountBecameActiveDuringRefresh() async {
+        let store = FakeStore(); store.secrets[id] = fresh
+        let counters = Counters()
+        var becameActive = false
+        let sut = makeRefresher(store: store, counters: counters, expired: true,
+                                refresh: { _ in becameActive = true; return .refreshed(rotatedSecret) },
+                                probe: { _ in .usage(makeSnapshot(40)) })
+
+        let updated = await sut.refreshRound(targets: [target], now: now,
+                                             activeID: { becameActive ? accountID : nil },
+                                             excludedID: { nil })
+
+        XCTAssertTrue(store.writes.isEmpty, "활성이 됐으면 라이브 자격증명이 authoritative")
+        XCTAssertEqual(store.secrets[id], fresh, "기존 스냅샷 보존")
+        XCTAssertTrue(counters.probedBytes.isEmpty, "이번 라운드는 그 계정을 건너뛴다")
+        XCTAssertTrue(updated.isEmpty)
+    }
+
+    // MARK: 왕복 중 adopt/재로그인으로 스냅샷이 바뀌면 구 회전본으로 덮지 않는다
+
+    func testRotatedSecretDiscardedWhenSnapshotChangedDuringRefresh() async {
+        let store = FakeStore(); store.secrets[id] = fresh
+        let relogin = Data("relogin-token".utf8)
+        store.onLockEnter = { store.secrets[accountID] = relogin }
+        let counters = Counters()
+        let sut = makeRefresher(store: store, counters: counters, expired: true,
+                                refresh: { _ in .refreshed(rotatedSecret) })
+
+        _ = await sut.refreshRound(targets: [target], now: now,
+                                   activeID: { nil }, excludedID: { nil })
+
+        XCTAssertTrue(store.writes.isEmpty)
+        XCTAssertEqual(store.secrets[id], relogin, "신규 로그인 스냅샷을 구 세션 회전본으로 덮지 않는다")
+    }
+
+    // MARK: 신원/형태 검증 실패 — 손상·타 계정 바이트가 스냅샷을 덮지 못한다
+
+    func testRotatedSecretRejectedByAdapterIsNotStored() async {
+        let store = FakeStore(); store.secrets[id] = fresh
+        let counters = Counters()
+        let sut = makeRefresher(store: store, counters: counters, expired: true,
+                                refresh: { _ in .refreshed(rotatedSecret) },
+                                accepts: { _, _ in false })
+
+        _ = await sut.refreshRound(targets: [target], now: now,
+                                   activeID: { nil }, excludedID: { nil })
+
+        XCTAssertTrue(store.writes.isEmpty)
+        XCTAssertEqual(store.secrets[id], fresh)
+        XCTAssertTrue(counters.probedBytes.isEmpty)
+    }
+
+    func testAcceptsRotatedSecretReceivesProfileEmail() async {
+        let store = FakeStore(); store.secrets[id] = fresh
+        let counters = Counters()
+        var seenEmail: String?
+        let sut = makeRefresher(store: store, counters: counters, expired: true,
+                                refresh: { _ in .refreshed(rotatedSecret) },
+                                accepts: { _, email in seenEmail = email; return true })
+
+        _ = await sut.refreshRound(targets: [target], now: now,
+                                   activeID: { nil }, excludedID: { nil })
+
+        XCTAssertEqual(seenEmail, email, "검증 기준은 그 계정의 이메일이어야 한다")
+    }
+
+    // MARK: 죽은 refresh 토큰 — 마킹 없이 긴 백오프만
+
+    func testInvalidatedRefreshSetsLongBackoffAndMarksNothing() async {
+        let store = FakeStore(); store.secrets[id] = fresh
+        let counters = Counters()
+        let sut = makeRefresher(store: store, counters: counters, expired: true,
+                                refresh: { _ in .invalidated })
+
+        let updated = await sut.refreshRound(targets: [target], now: now,
+                                             activeID: { nil }, excludedID: { nil })
+
+        XCTAssertTrue(updated.isEmpty)
+        XCTAssertTrue(counters.probedBytes.isEmpty, "죽은 토큰은 조회도 하지 않는다")
+        XCTAssertEqual(sut.deadBackoffUntil(id), now.addingTimeInterval(24 * 3600))
+        XCTAssertTrue(store.writes.isEmpty, "게이지 전용 — 아무것도 마킹하지 않는다")
+    }
+
+    func testDeadBackoffSkipsAccountUntilItExpires() async {
+        let store = FakeStore(); store.secrets[id] = fresh
+        let counters = Counters()
+        let sut = makeRefresher(store: store, counters: counters, expired: true,
+                                refresh: { _ in .invalidated })
+
+        _ = await sut.refreshRound(targets: [target], now: now,
+                                   activeID: { nil }, excludedID: { nil })
+        XCTAssertEqual(counters.refreshCalls, 1)
+
+        // 백오프 안 — 아예 건너뛴다
+        _ = await sut.refreshRound(targets: [target], now: now.addingTimeInterval(3600),
+                                   activeID: { nil }, excludedID: { nil })
+        XCTAssertEqual(counters.refreshCalls, 1)
+
+        // 백오프가 지나면 다시 시도한다
+        _ = await sut.refreshRound(targets: [target], now: now.addingTimeInterval(25 * 3600),
+                                   activeID: { nil }, excludedID: { nil })
+        XCTAssertEqual(counters.refreshCalls, 2)
+    }
+
+    // MARK: transient 실패 — 계정당 재시도 쿨다운으로 백오프
+
+    func testTransientFailureBacksOffUntilRetryCooldownElapses() async {
+        let store = FakeStore(); store.secrets[id] = fresh
+        let counters = Counters()
+        let sut = makeRefresher(store: store, counters: counters, expired: true,
+                                refresh: { _ in .transient }, retryCooldown: 600)
+
+        _ = await sut.refreshRound(targets: [target], now: now,
+                                   activeID: { nil }, excludedID: { nil })
+        XCTAssertEqual(counters.refreshCalls, 1)
+        XCTAssertTrue(counters.probedBytes.isEmpty, "만료 토큰으로는 조회하지 않는다")
+
+        // 쿨다운 안 — 팝오버를 다시 열어도 회전 시도를 반복하지 않는다
+        _ = await sut.refreshRound(targets: [target], now: now.addingTimeInterval(300),
+                                   activeID: { nil }, excludedID: { nil })
+        XCTAssertEqual(counters.refreshCalls, 1)
+
+        // 쿨다운 경과 — 재시도
+        _ = await sut.refreshRound(targets: [target], now: now.addingTimeInterval(601),
+                                   activeID: { nil }, excludedID: { nil })
+        XCTAssertEqual(counters.refreshCalls, 2)
+    }
+
+    // MARK: 조회 실패는 게이지를 마지막 값에 둔다
+
+    func testProbeStaleOrTransientYieldsNoUsageAndNoMarking() async {
+        for outcome in [InactiveGaugeProbeOutcome.stale, .transient] {
+            let store = FakeStore(); store.secrets[id] = fresh
+            let counters = Counters()
+            let sut = makeRefresher(store: store, counters: counters, expired: false,
+                                    probe: { _ in outcome })
+
+            let updated = await sut.refreshRound(targets: [target], now: now,
+                                                 activeID: { nil }, excludedID: { nil })
+
+            XCTAssertTrue(updated.isEmpty)
+            XCTAssertTrue(store.writes.isEmpty)
+        }
+    }
+
+    // MARK: 여러 계정 — 하나가 실패해도 나머지는 계속 돈다
+
+    func testOneAccountFailureDoesNotStopTheRound() async {
+        let dead = UUID(), good = UUID()
+        let store = FakeStore()
+        store.secrets[dead] = Data("dead".utf8)
+        store.secrets[good] = fresh
+        let counters = Counters()
+        let adapter = FakeAdapter(
+            expiry: { $0 == Data("dead".utf8) ? fixedNow.addingTimeInterval(-60)
+                                              : fixedNow.addingTimeInterval(3600) },
+            refreshResult: { _ in counters.refreshCalls += 1; return .invalidated },
+            probeResult: { secret in counters.probedBytes.append(secret); return .usage(makeSnapshot(7)) })
+        let sut = InactiveGaugeRefresher(adapter: adapter, store: store,
+                                         retryCooldown: 600, deadRefreshCooldown: 24 * 3600)
+
+        let updated = await sut.refreshRound(
+            targets: [.init(id: dead, emailAddress: email), .init(id: good, emailAddress: email)],
+            now: now, activeID: { nil }, excludedID: { nil })
+
+        XCTAssertNil(updated[dead])
+        XCTAssertEqual(updated[good]?.fiveHourPercent, 7)
+    }
+
+    // MARK: onUsage — 라운드가 끝나기 전에 계정 단위로 즉시 반영된다
+
+    func testOnUsageFiresPerAccountDuringTheRound() async {
+        let a = UUID(), b = UUID()
+        let store = FakeStore()
+        store.secrets[a] = fresh; store.secrets[b] = fresh
+        let counters = Counters()
+        let sut = makeRefresher(store: store, counters: counters, expired: false,
+                                probe: { _ in .usage(makeSnapshot(5)) })
+
+        var order: [UUID] = []
+        let updated = await sut.refreshRound(
+            targets: [.init(id: a, emailAddress: email), .init(id: b, emailAddress: email)],
+            now: now, activeID: { nil }, excludedID: { nil },
+            onUsage: { id, _ in order.append(id) })
+
+        XCTAssertEqual(order, [a, b], "게이지가 계정 순서대로 하나씩 차오른다")
+        XCTAssertEqual(updated.count, 2)
+    }
+
+    // MARK: 스냅샷이 없는 계정은 조용히 건너뛴다
+
+    func testMissingSecretSkipsAccount() async {
+        let store = FakeStore()   // 비어 있음
+        let counters = Counters()
+        let sut = makeRefresher(store: store, counters: counters, expired: true,
+                                refresh: { _ in .refreshed(rotatedSecret) })
+
+        let updated = await sut.refreshRound(targets: [target], now: now,
+                                             activeID: { nil }, excludedID: { nil })
+
+        XCTAssertTrue(updated.isEmpty)
+        XCTAssertEqual(counters.refreshCalls, 0)
+    }
+}

--- a/Tests/MobiusCoreTests/InactiveGaugeRefresherTests.swift
+++ b/Tests/MobiusCoreTests/InactiveGaugeRefresherTests.swift
@@ -26,7 +26,8 @@ final class InactiveGaugeRefresherTests: XCTestCase {
         var secrets: [UUID: Data] = [:]
         var writes: [(UUID, Data)] = []
         /// 락 진입 시점에 호출 — "HTTP 왕복 중 스냅샷이 바뀌는" 상황을 주입한다.
-        var onLockEnter: (() -> Void)?
+        /// 자기 자신을 인자로 넘겨, 훅이 스토어를 캡처해 참조 순환을 만들지 않게 한다.
+        var onLockEnter: ((FakeStore) -> Void)?
 
         func secretData(for id: UUID) throws -> Data? { secrets[id] }
 
@@ -37,7 +38,7 @@ final class InactiveGaugeRefresherTests: XCTestCase {
 
         @discardableResult
         func withCredentialLock<T>(_ id: UUID, _ body: () throws -> T) rethrows -> T {
-            onLockEnter?()
+            onLockEnter?(self)
             return try body()
         }
     }
@@ -67,9 +68,16 @@ final class InactiveGaugeRefresherTests: XCTestCase {
     let rotated = rotatedSecret
 
     /// 관찰용 카운터를 공유하기 위한 참조 상자 (스텁이 struct라 값 캡처가 안 되므로).
+    /// 테스트는 전부 메인 액터에서 직렬로 돌아 실제 경합은 없다.
     final class Counters: @unchecked Sendable {
         var refreshCalls = 0
         var probedBytes: [Data] = []
+    }
+
+    /// @Sendable 스텁 클로저가 관찰값을 쓰기 위한 상자 — 지역 var 직접 변형(Swift 6 금지)을 피한다.
+    final class Box<T>: @unchecked Sendable {
+        var value: T
+        init(_ value: T) { self.value = value }
     }
 
     private func makeRefresher(store: FakeStore,
@@ -160,13 +168,13 @@ final class InactiveGaugeRefresherTests: XCTestCase {
     func testRotatedSecretDiscardedWhenAccountBecameActiveDuringRefresh() async {
         let store = FakeStore(); store.secrets[id] = fresh
         let counters = Counters()
-        var becameActive = false
+        let becameActive = Box(false)
         let sut = makeRefresher(store: store, counters: counters, expired: true,
-                                refresh: { _ in becameActive = true; return .refreshed(rotatedSecret) },
+                                refresh: { _ in becameActive.value = true; return .refreshed(rotatedSecret) },
                                 probe: { _ in .usage(makeSnapshot(40)) })
 
         let updated = await sut.refreshRound(targets: [target], now: now,
-                                             activeID: { becameActive ? accountID : nil },
+                                             activeID: { becameActive.value ? accountID : nil },
                                              excludedID: { nil })
 
         XCTAssertTrue(store.writes.isEmpty, "활성이 됐으면 라이브 자격증명이 authoritative")
@@ -180,7 +188,7 @@ final class InactiveGaugeRefresherTests: XCTestCase {
     func testRotatedSecretDiscardedWhenSnapshotChangedDuringRefresh() async {
         let store = FakeStore(); store.secrets[id] = fresh
         let relogin = Data("relogin-token".utf8)
-        store.onLockEnter = { store.secrets[accountID] = relogin }
+        store.onLockEnter = { $0.secrets[accountID] = relogin }
         let counters = Counters()
         let sut = makeRefresher(store: store, counters: counters, expired: true,
                                 refresh: { _ in .refreshed(rotatedSecret) })
@@ -212,15 +220,15 @@ final class InactiveGaugeRefresherTests: XCTestCase {
     func testAcceptsRotatedSecretReceivesProfileEmail() async {
         let store = FakeStore(); store.secrets[id] = fresh
         let counters = Counters()
-        var seenEmail: String?
+        let seenEmail = Box<String?>(nil)
         let sut = makeRefresher(store: store, counters: counters, expired: true,
                                 refresh: { _ in .refreshed(rotatedSecret) },
-                                accepts: { _, email in seenEmail = email; return true })
+                                accepts: { _, email in seenEmail.value = email; return true })
 
         _ = await sut.refreshRound(targets: [target], now: now,
                                    activeID: { nil }, excludedID: { nil })
 
-        XCTAssertEqual(seenEmail, email, "검증 기준은 그 계정의 이메일이어야 한다")
+        XCTAssertEqual(seenEmail.value, email, "검증 기준은 그 계정의 이메일이어야 한다")
     }
 
     // MARK: 죽은 refresh 토큰 — 마킹 없이 긴 백오프만

--- a/Tests/MobiusCoreTests/InactiveGaugeRefresherTests.swift
+++ b/Tests/MobiusCoreTests/InactiveGaugeRefresherTests.swift
@@ -25,13 +25,18 @@ final class InactiveGaugeRefresherTests: XCTestCase {
     final class FakeStore: GaugeSecretStore, @unchecked Sendable {
         var secrets: [UUID: Data] = [:]
         var writes: [(UUID, Data)] = []
+        /// 쓰기 실패 주입 (디스크 풀 등) — capture-or-nothing 계약 검증용.
+        var failWrites = false
         /// 락 진입 시점에 호출 — "HTTP 왕복 중 스냅샷이 바뀌는" 상황을 주입한다.
         /// 자기 자신을 인자로 넘겨, 훅이 스토어를 캡처해 참조 순환을 만들지 않게 한다.
         var onLockEnter: ((FakeStore) -> Void)?
 
         func secretData(for id: UUID) throws -> Data? { secrets[id] }
 
+        struct WriteFailed: Error {}
+
         func setSecretData(_ data: Data, for id: UUID) throws {
+            if failWrites { throw WriteFailed() }
             secrets[id] = data
             writes.append((id, data))
         }
@@ -76,8 +81,38 @@ final class InactiveGaugeRefresherTests: XCTestCase {
 
     /// @Sendable 스텁 클로저가 관찰값을 쓰기 위한 상자 — 지역 var 직접 변형(Swift 6 금지)을 피한다.
     final class Box<T>: @unchecked Sendable {
-        var value: T
-        init(_ value: T) { self.value = value }
+        private let lock = NSLock()
+        private var stored: T
+        var value: T {
+            get { lock.lock(); defer { lock.unlock() }; return stored }
+            set { lock.lock(); stored = newValue; lock.unlock() }
+        }
+        init(_ value: T) { self.stored = value }
+    }
+
+    /// 1회성 게이트 — 스텁이 특정 지점에 도달했음을 테스트에 알리고(open), 테스트가 열어줄 때까지
+    /// 스텁을 세워둔다(wait). 취소 타이밍을 sleep 없이 결정론적으로 고정하기 위한 것이다.
+    /// 스텁 본문은 nonisolated async 컨텍스트에서 돌므로 실제로 스레드 안전해야 한다.
+    final class Gate: @unchecked Sendable {
+        private let lock = NSLock()
+        private var opened = false
+        private var waiters: [CheckedContinuation<Void, Never>] = []
+
+        func open() {
+            lock.lock()
+            opened = true
+            let pending = waiters
+            waiters = []
+            lock.unlock()
+            pending.forEach { $0.resume() }
+        }
+
+        func wait() async {
+            await withCheckedContinuation { (c: CheckedContinuation<Void, Never>) in
+                lock.lock()
+                if opened { lock.unlock(); c.resume() } else { waiters.append(c); lock.unlock() }
+            }
+        }
     }
 
     private func makeRefresher(store: FakeStore,
@@ -306,8 +341,26 @@ final class InactiveGaugeRefresherTests: XCTestCase {
                                                  activeID: { nil }, excludedID: { nil })
 
             XCTAssertTrue(updated.isEmpty)
-            XCTAssertTrue(store.writes.isEmpty)
+            XCTAssertEqual(counters.refreshCalls, 0, "만료 전이므로 회전 시도 자체가 없다")
         }
+    }
+
+    /// refresh는 성공해 회전본이 저장됐는데 그 직후 조회가 실패한 경우. 저장을 되돌리지 않고
+    /// 게이지만 마지막 값에 남는다 — 다음 라운드는 신선한 토큰으로 곧바로 조회한다.
+    func testProbeFailureAfterSuccessfulRefreshKeepsRotatedSnapshot() async {
+        let store = FakeStore(); store.secrets[id] = fresh
+        let counters = Counters()
+        let sut = makeRefresher(store: store, counters: counters, expired: true,
+                                refresh: { _ in .refreshed(rotatedSecret) },
+                                probe: { _ in .transient })
+
+        let updated = await sut.refreshRound(targets: [target], now: now,
+                                             activeID: { nil }, excludedID: { nil })
+
+        XCTAssertTrue(updated.isEmpty, "게이지는 마지막 값에 남는다")
+        XCTAssertEqual(store.secrets[id], rotatedSecret, "조회 실패가 저장된 회전본을 되돌리지 않는다")
+        XCTAssertNil(sut.lastRefreshAttempt(id), "refresh는 성공했으므로 쿨다운은 해제 상태")
+        XCTAssertNil(sut.deadBackoffUntil(id), "조회 실패는 죽은 토큰이 아니므로 백오프 없음")
     }
 
     // MARK: 여러 계정 — 하나가 실패해도 나머지는 계속 돈다
@@ -336,21 +389,26 @@ final class InactiveGaugeRefresherTests: XCTestCase {
 
     // MARK: onUsage — 라운드가 끝나기 전에 계정 단위로 즉시 반영된다
 
-    func testOnUsageFiresPerAccountDuringTheRound() async {
+    /// 순서만 보면 "라운드 끝에 모아서 두 번 호출"과 구분되지 않는다. 조회와 반영을 한 로그에
+    /// 섞어 적어, a의 게이지가 **b를 조회하기 전에** 반영됨을 고정한다.
+    func testOnUsageFiresBeforeTheNextAccountIsProbed() async {
         let a = UUID(), b = UUID()
         let store = FakeStore()
         store.secrets[a] = fresh; store.secrets[b] = fresh
         let counters = Counters()
+        let log = Box<[String]>([])
         let sut = makeRefresher(store: store, counters: counters, expired: false,
-                                probe: { _ in .usage(makeSnapshot(5)) })
+                                probe: { _ in log.value.append("probe"); return .usage(makeSnapshot(5)) })
 
         var order: [UUID] = []
         let updated = await sut.refreshRound(
             targets: [.init(id: a, emailAddress: email), .init(id: b, emailAddress: email)],
             now: now, activeID: { nil }, excludedID: { nil },
-            onUsage: { id, _ in order.append(id) })
+            onUsage: { id, _ in log.value.append("usage"); order.append(id) })
 
-        XCTAssertEqual(order, [a, b], "게이지가 계정 순서대로 하나씩 차오른다")
+        XCTAssertEqual(log.value, ["probe", "usage", "probe", "usage"],
+                       "반영이 다음 계정 조회 뒤로 밀리면 [probe, probe, usage, usage]가 된다")
+        XCTAssertEqual(order, [a, b], "계정 순서대로")
         XCTAssertEqual(updated.count, 2)
     }
 
@@ -367,5 +425,99 @@ final class InactiveGaugeRefresherTests: XCTestCase {
 
         XCTAssertTrue(updated.isEmpty)
         XCTAssertEqual(counters.refreshCalls, 0)
+    }
+
+    // MARK: 취소 — 쉴드는 회전을 완주시키고, 루프는 다음 계정으로 넘어가지 않는다
+
+    /// PR #7 리뷰의 차단 지적(회전 유실 brick 창)에 대응하는 불변식. 전환 진입의 quiesce가
+    /// 라운드를 취소해도 **진행 중인 refresh POST는 끊기지 않고 저장까지 완주**해야 한다.
+    /// 중간에 끊기면 서버는 회전을 커밋했는데 회전본은 유실돼 그 계정이 벽돌이 된다.
+    func testRefreshIsShieldedFromCancellationAndStillStoresRotated() async {
+        let store = FakeStore(); store.secrets[accountID] = freshSecret
+        let counters = Counters()
+        let entered = Gate(), mayReturn = Gate()
+        let cancelledInsideRefresh = Box(true)
+        let sut = makeRefresher(
+            store: store, counters: counters, expired: true,
+            refresh: { _ in
+                entered.open()                                  // 테스트에 "POST 발사됨" 알림
+                await mayReturn.wait()                          // 테스트가 취소를 걸 시간을 준다
+                cancelledInsideRefresh.value = Task.isCancelled  // 쉴드가 취소를 막았는가
+                return .refreshed(rotatedSecret)
+            },
+            probe: { _ in .usage(makeSnapshot(9)) })
+
+        let round = Task { @MainActor in
+            await sut.refreshRound(targets: [self.target], now: fixedNow,
+                                   activeID: { nil }, excludedID: { nil })
+        }
+        await entered.wait()
+        round.cancel()          // ← 전환 진입 시 quiesce가 하는 일
+        mayReturn.open()
+        let updated = await round.value
+
+        XCTAssertFalse(cancelledInsideRefresh.value,
+                       "쉴드 Task는 상위 취소를 상속하지 않아야 한다")
+        XCTAssertEqual(store.secrets[accountID], rotatedSecret,
+                       "취소가 회전본 저장을 막으면 그 계정은 벽돌이 된다")
+        XCTAssertEqual(updated[accountID]?.fiveHourPercent, 9)
+    }
+
+    /// 취소의 효력은 "다음 계정으로 진입하지 않는다"까지다 — 대기가 현재 계정의 진행 중 HTTP
+    /// 완료까지로 바운드된다는 quiesce 설계의 근거.
+    func testCancellationStopsBeforeEnteringTheNextAccount() async {
+        let first = UUID(), second = UUID()
+        let store = FakeStore()
+        store.secrets[first] = freshSecret
+        store.secrets[second] = freshSecret
+        let counters = Counters()
+        let entered = Gate(), mayReturn = Gate()
+        let sut = makeRefresher(
+            store: store, counters: counters, expired: false,
+            probe: { _ in
+                entered.open()
+                await mayReturn.wait()
+                return .usage(makeSnapshot(3))
+            })
+
+        let round = Task { @MainActor in
+            await sut.refreshRound(
+                targets: [.init(id: first, emailAddress: accountEmail),
+                          .init(id: second, emailAddress: accountEmail)],
+                now: fixedNow, activeID: { nil }, excludedID: { nil })
+        }
+        await entered.wait()    // 첫 계정 조회 진행 중
+        round.cancel()
+        mayReturn.open()
+        let updated = await round.value
+
+        XCTAssertEqual(counters.probedBytes.count, 1, "두 번째 계정에는 진입하지 않는다")
+        XCTAssertEqual(updated.count, 1, "첫 계정의 결과는 버리지 않는다")
+        XCTAssertNotNil(updated[first])
+        XCTAssertNil(updated[second])
+    }
+
+    // MARK: 저장 실패 — 성공으로 둔갑시키지 않는다 (brick 경로)
+
+    /// PR #7 리뷰의 두 번째 차단 지적. 회전본 쓰기가 실패했는데 성공으로 처리하면, 스냅샷에는
+    /// 이미 서버에서 소비된 구 refresh 토큰이 남은 채 쿨다운까지 풀려 그 계정이 벽돌이 된다.
+    /// `try?`로 되돌아가면 이 테스트가 죽는다.
+    func testStoreFailureIsNotTreatedAsSuccess() async {
+        let store = FakeStore()
+        store.secrets[id] = fresh
+        store.failWrites = true
+        let counters = Counters()
+        let sut = makeRefresher(store: store, counters: counters, expired: true,
+                                refresh: { _ in .refreshed(rotatedSecret) },
+                                probe: { _ in .usage(makeSnapshot(50)) })
+
+        let updated = await sut.refreshRound(targets: [target], now: now,
+                                             activeID: { nil }, excludedID: { nil })
+
+        XCTAssertTrue(updated.isEmpty, "저장 못 한 회전본으로 게이지를 갱신하면 안 된다")
+        XCTAssertTrue(counters.probedBytes.isEmpty, "저장 실패 시 이번 라운드는 그 계정을 건너뛴다")
+        XCTAssertEqual(store.secrets[id], fresh, "저장 스냅샷은 그대로")
+        XCTAssertEqual(sut.lastRefreshAttempt(id), now,
+                       "성공이 아니므로 재시도 쿨다운이 해제되면 안 된다")
     }
 }


### PR DESCRIPTION
비활성 계정의 게이지를 되살리는 루프 — 만료 판정 → refresh → credential lock 안 원자 검증 저장 → usage 조회 — 가 `AppState`에 Codex 전용으로 인라인돼 있습니다. 이 루프를 코어로 내리고, 프로바이더별로 다른 부분만 어댑터로 주입하도록 바꿉니다. **동작 변경은 없습니다.**

## 왜

**1. 자격증명 안전 불변식이 테스트 밖에 있습니다 (이게 주된 이유입니다)**

`MobiusApp`에는 테스트 타깃이 없습니다. 그래서 PR #7 리뷰에서 짚어주셨던 것들 —

- 활성 재확인 TOCTOU (refresh 왕복 중 그 계정이 활성이 되면 회전본 폐기)
- credential lock 안 스냅샷 재확인 (왕복 중 adopt/재로그인이 끼면 신규 스냅샷을 구 회전본으로 덮지 않기)
- capture-or-nothing 저장 (`try?`가 저장 실패를 성공으로 둔갑시키던 문제의 수정)

— 이 전부 **컴파일은 되지만 검증되지는 않는 상태**로 남아 있습니다. 회전 토큰을 잃으면 그 계정이 벽돌이 되는 경로인데, 되돌아가 확인할 수단이 없습니다.

**2. 세 번째 프로바이더는 이 120여 줄을 통째로 복제해야 합니다**

이슈 #8(Antigravity)과 #22(Grok) 모두 같은 모양입니다 — 저장 스냅샷, 만료되는 access 토큰, refresh로 되살리기, 별도 quota 엔드포인트. 복제하면 위 안전 불변식도 같이 복제되고, 어느 한 쪽만 고쳐지는 클래스의 버그가 생깁니다.

## 무엇을

`MobiusCore/InactiveGaugeRefresher.swift` — 루프 본체. 프로바이더가 아래 넷만 제공하면 그대로 돕니다.

```swift
public protocol InactiveGaugeProvider: Sendable {
    var provider: Provider { get }
    func accessTokenExpiry(fromSecret secret: Data) -> Date?
    func refresh(secret: Data) async -> InactiveGaugeRefreshOutcome
    func acceptsRotatedSecret(_ rotated: Data, forEmail email: String) -> Bool
    func probeUsage(secret: Data, now: Date) async -> InactiveGaugeProbeOutcome
}
```

`MobiusCore/CodexGaugeAdapter.swift` — Codex 구현. 기존 부품(`CodexAuthBlob` / `CodexTokenRefresher` / `CodexUsageProber` / `CodexConfigIO`)을 **조립만** 합니다. 판정 로직은 하나도 새로 만들지 않았습니다.

`AppState`는 `-103 / +57`. 프로바이더별 필드 6개(`codexUsageTask`, `codexProber`, `codexRefresher`, `lastCodexRefreshAttemptAt`, `codexRefreshDeadUntil`, `codexDeadRefreshCooldown`)가 `[Provider: …]` 두 개로 접혔습니다.

```swift
private var gaugeTasks: [Provider: Task<Void, Never>] = [:]
private lazy var gaugeRefreshers: [Provider: InactiveGaugeRefresher] = [
    .codex: InactiveGaugeRefresher(adapter: CodexGaugeAdapter(io: codexIO), store: store, …),
]
```

## 보존한 것

동작이 하나도 바뀌지 않도록 아래를 그대로 옮겼습니다.

- **활성/전환 진행중 계정은 절대 refresh하지 않습니다.** 활성 ID는 매 계정 fresh-read하고, 저장 직전 credential lock 안에서 한 번 더 확인합니다.
- **회전본은 셋을 모두 통과할 때만 저장합니다** — 스냅샷 재확인, 형태 인식, 신원 일치. 하나라도 어긋나면 기존 스냅샷을 보존합니다.
- **refresh POST는 취소 쉴드(자식 `Task`) 안에서** 돕니다. 왕복 중 취소로 회전본을 잃지 않습니다.
- **죽은 토큰은 아무것도 마킹하지 않고** 24시간 백오프만, transient는 계정당 10분 재시도 쿨다운.
- **게이지는 계정 단위로 즉시 반영**됩니다(`onUsage` 콜백). 라운드가 끝날 때까지 모아뒀다 한꺼번에 칠하지 않습니다 — 기존 UI 체감 유지를 위해 일부러 남긴 부분입니다.
- 뷰가 부르는 `refreshCodexUsageIfStale()` 이름도 유지했습니다(한 줄 래퍼).

의도적으로 **손대지 않은** 것도 적어둡니다.

- `refreshUsageIfStale`(Claude): Codex와 의미론이 다릅니다 — `needsReauth` 마킹·알림·리셋 시각 교정을 합니다. 게이지 전용 방화벽인 Codex 경로와 억지로 합치면 그 비대칭이 무너집니다.
- `processCodexBatches`(활성 계정 in-band 경로), `CodexStatusRouter`, `SessionLogWatcher`.
- 전환 안내 문구의 `switch provider` (`Sources/MobiusApp/AppState.swift`의 "실행 중인 codex 세션은…"). 프로바이더가 늘면 **컴파일 에러로 잡히게** 해둔 자리라 그대로 뒀습니다.

## 테스트

`Tests/MobiusCoreTests/InactiveGaugeRefresherTests.swift` — 19개. 네트워크·파일 없이 인메모리 스토어와 스텁 어댑터로 위 불변식을 재현합니다. 취소 타이밍은 `Gate`(1회성 게이트)로 `sleep` 없이 결정론적으로 고정했습니다.

**"이 테스트가 정말 그 회귀를 잡는가"를 뮤테이션으로 확인했습니다.** 가드를 하나씩 제거해 대응 테스트가 죽는지 봤고, 9개 전부 잡혔습니다.

| 제거한 가드 | 죽는 테스트 |
|---|---|
| 취소 시 루프 이탈 | `testCancellationStopsBeforeEnteringTheNextAccount` |
| 취소 쉴드 (`Task {}` 제거) | `testRefreshIsShieldedFromCancellationAndStillStoresRotated` |
| 락 안 활성 재확인 | `testRotatedSecretDiscardedWhenAccountBecameActiveDuringRefresh` |
| 락 안 스냅샷 재확인 | `testRotatedSecretDiscardedWhenSnapshotChangedDuringRefresh` |
| 회전본 신원/형태 검증 | `testRotatedSecretRejectedByAdapterIsNotStored` 외 1 |
| 죽은 토큰 24h 백오프 | `testDeadBackoffSkipsAccountUntilItExpires` |
| 계정당 재시도 쿨다운 | `testTransientFailureBacksOffUntilRetryCooldownElapses` |
| 활성/전환중 refresh 금지 | `testActiveAccountIsNeverRefreshed` 외 1 |
| `onUsage` 즉시 반영 | `testOnUsageFiresBeforeTheNextAccountIsProbed` |
| 저장 실패 `do/catch` (→`try?`) | `testStoreFailureIsNotTreatedAsSuccess` |

첫 감사에서는 **취소 쉴드와 저장 실패 두 곳이 무테스트로 살아남았습니다** — 둘 다 PR #7에서 짚어주셨던 차단 지적의 대상이었는데, 코드에는 반영돼 있으면서 그 사실을 지키는 테스트는 없던 상태였습니다. 지금은 각각 쉴드를 걷으면 / `do/catch`를 `try?`로 되돌리면 실패합니다.

약한 단언도 함께 정리했습니다. probe 실패 테스트의 `store.writes.isEmpty`는 만료 전 경로라 **어떤 구현에서도 항상 참인 빈 단언**이었어서 `refreshCalls == 0`으로 바꾸고, 의미 있는 경로(refresh 성공 후 조회 실패 → 저장된 회전본을 되돌리지 않음)를 별도 테스트로 뺐습니다. `onUsage` 테스트는 순서만 보던 것을 조회/반영 인터리빙까지 고정하도록 바꿨습니다 — 이전 형태는 "라운드 끝에 일괄 반영"과 구분되지 않았습니다.

`swift test` — **276개 통과, 실패 0**.

## 과거 리뷰 기준으로 자체 감사한 것

이 저장소의 리뷰에서 반복적으로 요구되는 기준에 스스로 걸어봤고, 걸린 것들을 이 PR 안에서 고쳤습니다.

- **주석이 코드보다 과장되지 않게** (#7 "원천 차단은 과장", #10 "쓰기만 참", #6 문서 드리프트)
  - `@MainActor` 근거에서 틀린 주장을 뺐습니다. NSLock은 어느 스레드에서 쥐어도 상호배제되므로 "같은 액터일 때만 의미가 있다"는 서술은 거짓이었습니다. 실제 이유(호출측이 메인 액터이고 `activeID` 조회가 동기 계약)로 바꿨습니다.
  - "하나라도 어긋나면 기존 스냅샷을 보존한다"가 **파일 관점에서만 참**임을 명시했습니다. 200을 받은 시점에 서버측 회전은 이미 커밋돼 있어, 회전본을 버리면 스냅샷에 소비된 토큰이 남고 다음 라운드가 `.invalidated` → 24시간 백오프로 들어갑니다(게이지만 얼고, 방화벽이라 아무것도 마킹하지 않습니다). PR #7에서 "이 경우 폐기는 보존이 아니라 유실"이라고 짚어주신 것을 컴포넌트 주석에 그대로 남겨뒀습니다. 저장 실패도 같은 결과이며, 게이지 경로에는 Claude의 `.storeFailed → needsReauth` 같은 복구 표면이 없다는 점도 적었습니다.
- **미배선 표면 없게** (#7 `codexDeadRefresh`)
  - 쓰이지 않던 `InactiveGaugeRefresher.provider`를 `gaugeRefreshers` 키 유도에 사용해, 키와 어댑터가 어긋날 여지를 구조적으로 없앴습니다.
  - 테스트 관찰용 훅 2개는 `public` → `internal`로 내렸습니다(`@testable import`로 충분).
- **상수 단일화** (#7 UA 문자열 중복)
  - 게이지 전용인 죽은토큰 쿨다운을 `AppState`에서 코어의 `defaultDeadRefreshCooldown`으로 옮겼습니다(`nonisolated` — 기본 인자는 비격리 문맥에서 평가됩니다). 재시도 쿨다운은 Claude 경로와 공유하는 값이라 `AppState`가 계속 주입합니다.
- **같은 이유면 다른 경로에도** (#3 "`.claude` 필터가 여기만")
  - `quiesceGaugeTask` 호출부의 하드코딩 `.codex`를 스코프의 `provider`로 통일했습니다.

## 이 PR을 지금 여는 이유

이슈 #8은 아직 방향 회신 전입니다. 이 PR은 **그 결정과 독립적으로** 서 있도록 잘라뒀습니다 — Antigravity/Grok을 넣지 않기로 하시더라도, 테스트 없던 자격증명 경로에 테스트가 붙는 것만으로 남습니다. 반대로 넣기로 하시면 세 번째 프로바이더의 `AppState` diff가 어댑터 하나와 딕셔너리 한 줄로 줄어듭니다.

과한 선반영이라 판단하시면 편하게 닫아주세요. 지금 방향이 아니라는 신호도 그대로 유용합니다.
